### PR TITLE
Add support for getting the hints' flags of a window

### DIFF
--- a/lxqtxfitman.cpp
+++ b/lxqtxfitman.cpp
@@ -179,7 +179,7 @@ int XfitMan::getNumDesktop() const
 }
 
 QStringList XfitMan::getDesktopNames() const
-{  
+{
     QStringList ret;
     unsigned long length;
     unsigned char *data = 0;
@@ -1025,6 +1025,21 @@ XfitMan::WMState XfitMan::getWMState(Window _wid) const
         }
     }
     return state;
+}
+
+
+/************************************************
+
+ ************************************************/
+WMHintsFlags XfitMan::getWMHintsFlags(Window _wid) const
+{
+    XWMHints *hints = XGetWMHints(QX11Info::display(), _wid);
+    if (!hints)
+        return (WMHintsFlags) 0;
+    
+    WMHintsFlags flags = hints->flags;
+    XFree(hints);
+    return flags;
 }
 
 } // namespace LxQt

--- a/lxqtxfitman.h
+++ b/lxqtxfitman.h
@@ -92,6 +92,22 @@ struct WindowState
     bool Attention;     // indicates that some action in or with the window happened.
 };
 
+// A list of hints to the window manager
+// http://tronche.com/gui/x/xlib/ICC/client-to-window-manager/wm-hints.html
+enum WMHintsFlag
+{
+    WMInputHint = (1L << 0),
+    WMStateHint = (1L << 1),
+    WMIconPixmapHint = (1L << 2),
+    WMIconWindowHint = (1L << 3),
+    WMIconPositionHint = (1L << 4),
+    WMIconMaskHint = (1L << 5),
+    WMWindowGroupHint = (1L << 6),
+    WMAllHints = (WMInputHint | WMStateHint | WMIconPixmapHint | WMIconWindowHint
+        | WMIconPositionHint | WMIconMaskHint | WMWindowGroupHint),
+    WMUrgencyHint = (1L << 8)
+};
+typedef long WMHintsFlags;
 
 /**
  * @brief manages the Xlib apicalls
@@ -168,6 +184,11 @@ public:
      * Returns ICCCM WM_STATE
     */
     WMState getWMState(Window _wid) const;
+
+    /*!
+     * Returns the window's hints' flags
+     */
+    WMHintsFlags getWMHintsFlags(Window _wid) const;
 
     /*!
      * Returns the names of all virtual desktops. This is a list of UTF-8 encoding strings.


### PR DESCRIPTION
This is necessary for hadling the urgency hint asked in lxde/lxqt-panel#41.

Maybe there is a better way of doing it. Please leave your comments.

http://tronche.com/gui/x/xlib/ICC/client-to-window-manager/wm-hints.html
