### PR TITLE
Delay watching of config file changes until an event loop is running due to limitations of QFileSystemWatcher.

### DIFF
--- a/lxqtsettings.h
+++ b/lxqtsettings.h
@@ -86,6 +86,7 @@ protected:
     bool event(QEvent *event);
 
 protected slots:
+    void initWatch();
     virtual void fileChanged();
 
 private:


### PR DESCRIPTION
Internally LxQt::Settings uses QFileSystemWatcher to monitor file changes.
Unfortunately, QFileSystemWatcher stop working when it's created before running an event loop.
To workaround this limitation, we need to delay the creation of the watcher until the event loop is running.
This is required for use in lxqt-qtplugin where the settings are loaded before running QApplication.
