### PR TITLE
Don't update (extract) translations by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ file(GLOB TS_FILES
 # additional cmake files
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files")
+option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
If they are enabled by default in each build there will be, probably,
new .ts files. And they will not be commited. They are meant to be commited
in an Update Translations commit. They will be left behind and in the next
git fetch/git submodule update, they will have to be reset.

The proper solution is to update at an "regular" interval and have an
Translator call (freeze). More development savvy translators can also
update the translations themselves.
