### PR TITLE
[WIP] ConfigDialog: Removes manual icon update

### DIFF
--- a/configdialog/lxqtconfigdialog.cpp
+++ b/configdialog/lxqtconfigdialog.cpp
@@ -103,13 +103,6 @@ void ConfigDialog::showPage(QWidget* page)
     ui->moduleList->setCurrentRow(index);
 }
 
-bool ConfigDialog::event(QEvent * event)
-{
-    if (QEvent::ThemeChange == event->type())
-        updateIcons();
-    return QDialog::event(event);
-}
-
 void ConfigDialog::closeEvent(QCloseEvent* event)
 {
     emit save();
@@ -129,13 +122,6 @@ void ConfigDialog::dialogButtonsAction(QAbstractButton* button)
     {
         close();
     }
-}
-
-void ConfigDialog::updateIcons()
-{
-    for (int ix = 0; ix < mIcons.size(); ix++)
-        ui->moduleList->item(ix)->setIcon(XdgIcon::fromTheme(mIcons.at(ix)));
-    update();
 }
 
 ConfigDialog::~ConfigDialog()

--- a/configdialog/lxqtconfigdialog.h
+++ b/configdialog/lxqtconfigdialog.h
@@ -89,7 +89,6 @@ signals:
 
 protected:
     Settings* mSettings;
-    virtual bool event(QEvent * event) override;
     virtual void closeEvent(QCloseEvent* event) override;
 
 private:
@@ -100,7 +99,6 @@ private:
 
 private slots:
     void dialogButtonsAction(QAbstractButton* button);
-    void updateIcons();
 
 };
 


### PR DESCRIPTION
It's simply not needed anymore.
Disclaimer: This breaks the ABI. Every component that has a runtime
dependency on liblxqt needs to be recompiled.
