### PR TITLE
lxqtbacklight: Fix a FTBFS in superbuild mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,11 +139,11 @@ set(FORMS
 )
 
 set(POLKIT_FILES
-    ${CMAKE_BINARY_DIR}/org.lxqt.backlight.pkexec.policy
+    "${CMAKE_CURRENT_BINARY_DIR}/org.lxqt.backlight.pkexec.policy"
 )
 
 # Build Polkit file
-configure_file ( polkit/org.lxqt.backlight.pkexec.policy.in org.lxqt.backlight.pkexec.policy )
+configure_file ( polkit/org.lxqt.backlight.pkexec.policy.in "${CMAKE_CURRENT_BINARY_DIR}/org.lxqt.backlight.pkexec.policy" )
 install(FILES ${POLKIT_FILES} DESTINATION /usr/share/polkit-1/actions/)
 
 file(GLOB LXQT_CONFIG_FILES resources/*.conf)


### PR DESCRIPTION
Specify the output path of the polkit file.