### PR TITLE
Don't use automatic string conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,11 @@ target_compile_definitions(${LXQT_LIBRARY_NAME}
         "LXQT_VERSION=\"${LXQT_VERSION}\""
         "COMPILE_LIBLXQT"
         "QT_NO_FOREACH"
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
         "$<$<CONFIG:Release>:QT_NO_DEBUG_OUTPUT>"
         "$<$<CONFIG:Release>:QT_NO_WARNING_OUTPUT>"
 )

--- a/configdialog/lxqtconfigdialog.cpp
+++ b/configdialog/lxqtconfigdialog.cpp
@@ -126,7 +126,7 @@ void ConfigDialog::addPage(QWidget* page, const QString& name, const QStringList
         page->layout()->setMargin(0);
     }
 
-    QStringList icons = QStringList(iconNames) << "application-x-executable";
+    QStringList icons = QStringList(iconNames) << QL1S("application-x-executable");
     new QListWidgetItem(XdgIcon::fromTheme(icons), name, d->ui->moduleList);
     d->mIcons.append(icons);
     d->ui->stackedWidget->addWidget(page);

--- a/configdialog/lxqtconfigdialog.h
+++ b/configdialog/lxqtconfigdialog.h
@@ -58,7 +58,7 @@ public:
     /*!
      * Add a page to the configure dialog
      */
-    void addPage(QWidget* page, const QString& name, const QString& iconName="application-x-executable");
+    void addPage(QWidget* page, const QString& name, const QString& iconName = QLatin1String("application-x-executable"));
 
     /*!
      * Add a page to the configure dialog, attempting several alternative icons to find one in the theme

--- a/lxqtapplication.cpp
+++ b/lxqtapplication.cpp
@@ -60,8 +60,8 @@ void dbgMessageOutput(QtMsgType type, const QMessageLogContext &ctx, const QStri
     Q_UNUSED(ctx)
     QByteArray msgBuf = msgStr.toUtf8();
     const char* msg = msgBuf.constData();
-    QDir dir(XdgDirs::configHome().toUtf8() + QLatin1String("/lxqt"));
-    dir.mkpath(".");
+    QDir dir(XdgDirs::configHome() + QLatin1String("/lxqt"));
+    dir.mkpath(QL1S("."));
 
     const char* typestr;
     const char* color;
@@ -83,13 +83,13 @@ void dbgMessageOutput(QtMsgType type, const QMessageLogContext &ctx, const QStri
         color = COLOR_CRITICAL;
     }
 
-    QByteArray dt = QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss.zzz").toUtf8();
+    QByteArray dt = QDateTime::currentDateTime().toString(QL1S("yyyy-MM-dd hh:mm:ss.zzz")).toUtf8();
     if (isatty(STDERR_FILENO))
         fprintf(stderr, "%s %s(%p) %s: %s%s\n", color, QAPP_NAME, static_cast<void *>(qApp), typestr, msg, COLOR_RESET);
     else
         fprintf(stderr, "%s(%p) %s: %s\n", QAPP_NAME, static_cast<void *>(qApp), typestr, msg);
 
-    FILE *f = fopen(dir.absoluteFilePath("debug.log").toUtf8().constData(), "a+");
+    FILE *f = fopen(dir.absoluteFilePath(QL1S("debug.log")).toUtf8().constData(), "a+");
     fprintf(f, "%s %s(%p) %s: %s\n", dt.constData(), QAPP_NAME, static_cast<void *>(qApp), typestr, msg);
     fclose(f);
 
@@ -107,7 +107,7 @@ Application::Application(int &argc, char** argv)
         qInstallMessageHandler(dbgMessageOutput);
 #endif
 
-    setWindowIcon(QIcon(QString(LXQT_GRAPHICS_DIR) + "/lxqt_logo.png"));
+    setWindowIcon(QIcon(QFile::decodeName(LXQT_GRAPHICS_DIR) + QL1S("/lxqt_logo.png")));
     connect(Settings::globalSettings(), &GlobalSettings::lxqtThemeChanged, this, &Application::updateTheme);
     updateTheme();
 }
@@ -143,7 +143,7 @@ namespace
         {
             const int ret = write(instance->mSignalSock[0], &signo, sizeof (int));
             if (sizeof (int) != ret)
-                qCritical() << QStringLiteral("unable to write into socketpair, %1").arg(strerror(errno));
+                qCritical("unable to write into socketpair: %s", strerror(errno));
         } 
 
     public:
@@ -153,7 +153,7 @@ namespace
         {
             if (0 != socketpair(AF_UNIX, SOCK_STREAM, 0, mSignalSock))
             {
-                qCritical() << QStringLiteral("unable to create socketpair for correct signal handling: %1)").arg(strerror(errno));
+                qCritical("unable to create socketpair for correct signal handling: %s", strerror(errno));
                 return;
             }
 
@@ -162,7 +162,7 @@ namespace
                 int signo = 0;
                 int ret = read(mSignalSock[1], &signo, sizeof (int));
                 if (sizeof (int) != ret)
-                qCritical() << QStringLiteral("unable to read signal from socketpair, %1").arg(strerror(errno));
+                qCritical("unable to read signal from socketpair, %s", strerror(errno));
                 signalEmitter(signo);
             });
         }

--- a/lxqtautostartentry.cpp
+++ b/lxqtautostartentry.cpp
@@ -41,7 +41,7 @@ AutostartEntry::AutostartEntry(const QString& name):
     const QStringList& dirs = XdgDirs::autostartDirs();
     for (const QString& dir : dirs)
     {
-        const QString path = QString("%1/%2").arg(dir, name);
+        const QString path = QString::fromLatin1("%1/%2").arg(dir, name);
         if (QFile(path).exists())
         {
             mSystemFile.load(path);
@@ -50,7 +50,7 @@ AutostartEntry::AutostartEntry(const QString& name):
         }
     }
 
-    const QString path = QString("%1/%2").arg(XdgDirs::autostartHome(), name);
+    const QString path = QString::fromLatin1("%1/%2").arg(XdgDirs::autostartHome(), name);
     if (QFile(path).exists())
     {
         mLocalFile.load(path);
@@ -102,16 +102,16 @@ void AutostartEntry::setEnabled(bool enable)
 {
     XdgDesktopFile f = file();
     if (enable)
-        f.removeEntry("Hidden");
+        f.removeEntry(QL1S("Hidden"));
     else
-        f.setValue("Hidden", true);
+        f.setValue(QL1S("Hidden"), true);
 
     setFile(f);
 }
 
 bool AutostartEntry::isEnabled() const
 {
-    return !isEmpty() && !file().value("Hidden", false).toBool();
+    return !isEmpty() && !file().value(QL1S("Hidden"), false).toBool();
 }
 
 bool AutostartEntry::commit()

--- a/lxqtbacklight/linux_backend/linuxbackend.cpp
+++ b/lxqtbacklight/linux_backend/linuxbackend.cpp
@@ -39,9 +39,9 @@ LinuxBackend::LinuxBackend(QObject *parent):VirtualBackEnd(parent)
     if( isBacklightAvailable() ) {
         char *driver = lxqt_backlight_backend_get_driver();
         fileSystemWatcher = new QFileSystemWatcher(this);
-        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/actual_brightness").arg(driver));
-        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/brightness").arg(driver));
-        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/bl_power").arg(driver));
+        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/actual_brightness").arg(QL1S(driver)));
+        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/brightness").arg(QL1S(driver)));
+        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/bl_power").arg(QL1S(driver)));
         free(driver);
         actualBacklight = lxqt_backlight_backend_get();
         connect(fileSystemWatcher, &QFileSystemWatcher::fileChanged,

--- a/lxqtnotification.cpp
+++ b/lxqtnotification.cpp
@@ -92,7 +92,7 @@ void Notification::setHint(const QString& hintName, const QVariant& value)
 void Notification::setUrgencyHint(Urgency urgency)
 {
     Q_D(Notification);
-    d->mHints.insert("urgency", qvariant_cast<uchar>(urgency));
+    d->mHints.insert(QL1S("urgency"), qvariant_cast<uchar>(urgency));
 }
 
 void Notification::clearHints()
@@ -127,8 +127,8 @@ NotificationPrivate::NotificationPrivate(const QString& summary, Notification* p
     mTimeout(-1),
     q_ptr(parent)
 {
-    mInterface = new OrgFreedesktopNotificationsInterface("org.freedesktop.Notifications",
-                                                          "/org/freedesktop/Notifications",
+    mInterface = new OrgFreedesktopNotificationsInterface(QL1S("org.freedesktop.Notifications"),
+                                                          QL1S("/org/freedesktop/Notifications"),
                                                           QDBusConnection::sessionBus(), this);
     connect(mInterface, &OrgFreedesktopNotificationsInterface::NotificationClosed,
         this, &NotificationPrivate::notificationClosed);
@@ -150,8 +150,8 @@ void NotificationPrivate::update()
     }
     else
     {
-        if (mHints.contains("urgency") && mHints.value("urgency").toInt() != Notification::UrgencyLow)
-            QMessageBox::information(0, tr("Notifications Fallback"), mSummary + " \n\n " + mBody);
+        if (mHints.contains(QL1S("urgency")) && mHints.value(QL1S("urgency")).toInt() != Notification::UrgencyLow)
+            QMessageBox::information(0, tr("Notifications Fallback"), mSummary + QL1S(" \n\n ") + mBody);
     }
 }
 
@@ -164,7 +164,7 @@ void NotificationPrivate::setActions(QStringList actions, int defaultAction)
     for (int ix = 0; ix < N; ix++)
     {
         if (ix == defaultAction)
-            mActions.append("default");
+            mActions.append(QL1S("default"));
         else
             mActions.append(QString::number(ix));
         mActions.append(actions[ix]);
@@ -187,7 +187,7 @@ void NotificationPrivate::handleAction(uint id, QString key)
     qDebug() << "action invoked:" << key;
     bool ok = true;
     int keyId;
-    if (key == "default")
+    if (key == QL1S("default"))
         keyId = mDefaultAction;
     else
         keyId = key.toInt(&ok);

--- a/lxqtplugininfo.cpp
+++ b/lxqtplugininfo.cpp
@@ -74,14 +74,14 @@ QLibrary* PluginInfo::loadLibrary(const QString& libDir) const
 {
     const QFileInfo fi = QFileInfo(fileName());
     const QString path = fi.canonicalPath();
-    const QString baseName = value("X-LXQt-Library", fi.completeBaseName()).toString();
+    const QString baseName = value(QL1S("X-LXQt-Library"), fi.completeBaseName()).toString();
 
-    const QString soPath = QDir(libDir).filePath(QString("lib%2.so").arg(baseName));
+    const QString soPath = QDir(libDir).filePath(QString::fromLatin1("lib%2.so").arg(baseName));
     QLibrary* library = new QLibrary(soPath);
 
     if (!library->load())
     {
-        qWarning() << QString("Can't load plugin lib \"%1\"").arg(soPath) << library->errorString();
+        qWarning() << QString::fromLatin1("Can't load plugin lib \"%1\"").arg(soPath) << library->errorString();
         delete library;
         return 0;
     }
@@ -89,7 +89,7 @@ QLibrary* PluginInfo::loadLibrary(const QString& libDir) const
     const QString locale = QLocale::system().name();
     QTranslator* translator = new QTranslator(library);
 
-    translator->load(QString("%1/%2/%2_%3.qm").arg(path, baseName, locale));
+    translator->load(QString::fromLatin1("%1/%2/%2_%3.qm").arg(path, baseName, locale));
     qApp->installTranslator(translator);
 
     return library;
@@ -140,7 +140,7 @@ PluginInfoList PluginInfo::search(const QString& desktopFilesDir, const QString&
  ************************************************/
 QDebug operator<<(QDebug dbg, const LXQt::PluginInfo &pluginInfo)
 {
-    dbg.nospace() << QString("%1").arg(pluginInfo.id());
+    dbg.nospace() << QString::fromLatin1("%1").arg(pluginInfo.id());
     return dbg.space();
 }
 
@@ -159,13 +159,13 @@ QDebug operator<<(QDebug dbg, const LXQt::PluginInfo * const pluginInfo)
  ************************************************/
 QDebug operator<<(QDebug dbg, const PluginInfoList& list)
 {
-    dbg.nospace() << '(';
+    dbg.nospace() << QL1C('(');
     for (int i=0; i<list.size(); ++i)
     {
-        if (i) dbg.nospace() << ", ";
+        if (i) dbg.nospace() << QL1S(", ");
         dbg << list.at(i);
     }
-    dbg << ')';
+    dbg << QL1C(')');
     return dbg.space();
 }
 

--- a/lxqtplugininfo.h
+++ b/lxqtplugininfo.h
@@ -77,7 +77,7 @@ public:
     QString id() const { return mId; }
 
     //! This function is provided for convenience. It's equivalent to calling value("ServiceTypes").toString().
-    QString serviceType() const  { return value("ServiceTypes").toString(); }
+    QString serviceType() const  { return value(QL1S("ServiceTypes")).toString(); }
 
     //! Reimplemented from XdgDesktopFile.
     virtual bool isValid() const;
@@ -94,10 +94,10 @@ public:
 
       If the same filename is located under multiple directories only the first file should be used.
     */
-    static QList<PluginInfo> search(const QStringList& desktopFilesDirs, const QString& serviceType, const QString& nameFilter="*");
+    static QList<PluginInfo> search(const QStringList& desktopFilesDirs, const QString& serviceType, const QString& nameFilter = QLatin1String("*"));
 
     /// This function is provided for convenience. It's equivalent to new calling search(QString(desktopFilesDir), serviceType, nameFilter)
-    static QList<PluginInfo> search(const QString& desktopFilesDir, const QString& serviceType, const QString& nameFilter="*");
+    static QList<PluginInfo> search(const QString& desktopFilesDir, const QString& serviceType, const QString& nameFilter = QLatin1String("*"));
 
 private:
     QString mId;

--- a/lxqtpower/lxqtpowerproviders.cpp
+++ b/lxqtpower/lxqtpowerproviders.cpp
@@ -85,8 +85,8 @@ static bool dbusCall(const QString &service,
         {
             Notification::notify(
                                     QObject::tr("Power Manager Error"),
-                                    QObject::tr("QDBusInterface is invalid")+ "\n\n" + service + " " + path + " " + interface + " " + method,
-                                    "lxqt-logo.png");
+                                    QObject::tr("QDBusInterface is invalid") + QL1S("\n\n") + service + QL1C(' ') + path + QL1C(' ') + interface + QL1C(' ') + method,
+                                    QL1S("lxqt-logo.png"));
         }
         return false;
     }
@@ -100,8 +100,8 @@ static bool dbusCall(const QString &service,
         {
             Notification::notify(
                                     QObject::tr("Power Manager Error (D-BUS call)"),
-                                    msg.errorName() + "\n\n" + msg.errorMessage(),
-                                    "lxqt-logo.png");
+                                    msg.errorName() + QL1S("\n\n") + msg.errorMessage(),
+                                    QL1S("lxqt-logo.png"));
         }
     }
 
@@ -135,8 +135,8 @@ static bool dbusCallSystemd(const QString &service,
         {
             Notification::notify(
                                     QObject::tr("Power Manager Error"),
-                                    QObject::tr("QDBusInterface is invalid")+ "\n\n" + service + " " + path + " " + interface + " " + method,
-                                    "lxqt-logo.png");
+                                    QObject::tr("QDBusInterface is invalid") + QL1S("\n\n") + service + QL1C(' ') + path + QL1C(' ')+ interface + QL1C(' ') + method,
+                                    QL1S("lxqt-logo.png"));
         }
         return false;
     }
@@ -150,8 +150,8 @@ static bool dbusCallSystemd(const QString &service,
         {
             Notification::notify(
                                     QObject::tr("Power Manager Error (D-BUS call)"),
-                                    msg.errorName() + "\n\n" + msg.errorMessage(),
-                                    "lxqt-logo.png");
+                                    msg.errorName() + QL1S("\n\n") + msg.errorMessage(),
+                                    QL1S("lxqt-logo.png"));
         }
     }
 
@@ -161,7 +161,7 @@ static bool dbusCallSystemd(const QString &service,
 
     QString response = msg.arguments().constFirst().toString();
     qDebug() << "systemd:" << method << "=" << response;
-    return response == "yes" || response == "challenge";
+    return response == QL1S("yes") || response == QL1S("challenge");
 }
 
 
@@ -187,7 +187,7 @@ bool dbusGetProperty(const QString &service,
         return false;
     }
 
-    QDBusMessage msg = dbus.call("Get", dbus.interface(), property);
+    QDBusMessage msg = dbus.call(QL1S("Get"), dbus.interface(), property);
 
     if (!msg.errorName().isEmpty())
     {
@@ -241,13 +241,13 @@ bool UPowerProvider::canAction(Power::Action action) const
     switch (action)
     {
     case Power::PowerHibernate:
-        property = "CanHibernate";
-        command  = "HibernateAllowed";
+        property = QL1S("CanHibernate");
+        command  = QL1S("HibernateAllowed");
         break;
 
     case Power::PowerSuspend:
-        property = "CanSuspend";
-        command  = "SuspendAllowed";
+        property = QL1S("CanSuspend");
+        command  = QL1S("SuspendAllowed");
         break;
 
     default:
@@ -255,17 +255,17 @@ bool UPowerProvider::canAction(Power::Action action) const
     }
 
     return  dbusGetProperty(  // Whether the system is able to hibernate.
-                UPOWER_SERVICE,
-                UPOWER_PATH,
-                PROPERTIES_INTERFACE,
+                QL1S(UPOWER_SERVICE),
+                QL1S(UPOWER_PATH),
+                QL1S(PROPERTIES_INTERFACE),
                 QDBusConnection::systemBus(),
                 property
             )
             &&
             dbusCall( // Check if the caller has (or can get) the PolicyKit privilege to call command.
-                UPOWER_SERVICE,
-                UPOWER_PATH,
-                UPOWER_INTERFACE,
+                QL1S(UPOWER_SERVICE),
+                QL1S(UPOWER_PATH),
+                QL1S(UPOWER_INTERFACE),
                 QDBusConnection::systemBus(),
                 command,
                 // canAction should be always silent because it can freeze
@@ -283,11 +283,11 @@ bool UPowerProvider::doAction(Power::Action action)
     switch (action)
     {
     case Power::PowerHibernate:
-        command = "Hibernate";
+        command = QL1S("Hibernate");
         break;
 
     case Power::PowerSuspend:
-        command = "Suspend";
+        command = QL1S("Suspend");
         break;
 
     default:
@@ -295,9 +295,9 @@ bool UPowerProvider::doAction(Power::Action action)
     }
 
 
-    return dbusCall(UPOWER_SERVICE,
-             UPOWER_PATH,
-             UPOWER_INTERFACE,
+    return dbusCall(QL1S(UPOWER_SERVICE),
+             QL1S(UPOWER_PATH),
+             QL1S(UPOWER_INTERFACE),
              QDBusConnection::systemBus(),
              command );
 }
@@ -324,28 +324,28 @@ bool ConsoleKitProvider::canAction(Power::Action action) const
     switch (action)
     {
     case Power::PowerReboot:
-        command = "CanReboot";
+        command = QL1S("CanReboot");
         break;
 
     case Power::PowerShutdown:
-        command = "CanPowerOff";
+        command = QL1S("CanPowerOff");
         break;
 
     case Power::PowerHibernate:
-        command  = "CanHibernate";
+        command  = QL1S("CanHibernate");
         break;
 
     case Power::PowerSuspend:
-        command  = "CanSuspend";
+        command  = QL1S("CanSuspend");
         break;
 
     default:
         return false;
     }
 
-    return dbusCallSystemd(CONSOLEKIT_SERVICE,
-                    CONSOLEKIT_PATH,
-                    CONSOLEKIT_INTERFACE,
+    return dbusCallSystemd(QL1S(CONSOLEKIT_SERVICE),
+                    QL1S(CONSOLEKIT_PATH),
+                    QL1S(CONSOLEKIT_INTERFACE),
                     QDBusConnection::systemBus(),
                     command,
                     false,
@@ -363,28 +363,28 @@ bool ConsoleKitProvider::doAction(Power::Action action)
     switch (action)
     {
     case Power::PowerReboot:
-        command = "Reboot";
+        command = QL1S("Reboot");
         break;
 
     case Power::PowerShutdown:
-        command = "PowerOff";
+        command = QL1S("PowerOff");
         break;
 
     case Power::PowerHibernate:
-        command = "Hibernate";
+        command = QL1S("Hibernate");
         break;
 
     case Power::PowerSuspend:
-        command = "Suspend";
+        command = QL1S("Suspend");
         break;
 
     default:
         return false;
     }
 
-    return dbusCallSystemd(CONSOLEKIT_SERVICE,
-                CONSOLEKIT_PATH,
-                CONSOLEKIT_INTERFACE,
+    return dbusCallSystemd(QL1S(CONSOLEKIT_SERVICE),
+                QL1S(CONSOLEKIT_PATH),
+                QL1S(CONSOLEKIT_INTERFACE),
                 QDBusConnection::systemBus(),
                 command,
                 true
@@ -415,28 +415,28 @@ bool SystemdProvider::canAction(Power::Action action) const
     switch (action)
     {
     case Power::PowerReboot:
-        command = "CanReboot";
+        command = QL1S("CanReboot");
         break;
 
     case Power::PowerShutdown:
-        command = "CanPowerOff";
+        command = QL1S("CanPowerOff");
         break;
 
     case Power::PowerSuspend:
-        command = "CanSuspend";
+        command = QL1S("CanSuspend");
         break;
 
     case Power::PowerHibernate:
-        command = "CanHibernate";
+        command = QL1S("CanHibernate");
         break;
 
     default:
         return false;
     }
 
-    return dbusCallSystemd(SYSTEMD_SERVICE,
-                    SYSTEMD_PATH,
-                    SYSTEMD_INTERFACE,
+    return dbusCallSystemd(QL1S(SYSTEMD_SERVICE),
+                    QL1S(SYSTEMD_PATH),
+                    QL1S(SYSTEMD_INTERFACE),
                     QDBusConnection::systemBus(),
                     command,
                     false,
@@ -455,28 +455,28 @@ bool SystemdProvider::doAction(Power::Action action)
     switch (action)
     {
     case Power::PowerReboot:
-        command = "Reboot";
+        command = QL1S("Reboot");
         break;
 
     case Power::PowerShutdown:
-        command = "PowerOff";
+        command = QL1S("PowerOff");
         break;
 
     case Power::PowerSuspend:
-        command = "Suspend";
+        command = QL1S("Suspend");
         break;
 
     case Power::PowerHibernate:
-        command = "Hibernate";
+        command = QL1S("Hibernate");
         break;
 
     default:
         return false;
     }
 
-    return dbusCallSystemd(SYSTEMD_SERVICE,
-             SYSTEMD_PATH,
-             SYSTEMD_INTERFACE,
+    return dbusCallSystemd(QL1S(SYSTEMD_SERVICE),
+             QL1S(SYSTEMD_PATH),
+             QL1S(SYSTEMD_INTERFACE),
              QDBusConnection::systemBus(),
              command,
              true
@@ -504,20 +504,20 @@ bool LXQtProvider::canAction(Power::Action action) const
     switch (action)
     {
         case Power::PowerLogout:
-            command = "canLogout";
+            command = QL1S("canLogout");
             break;
         case Power::PowerReboot:
-            command = "canReboot";
+            command = QL1S("canReboot");
             break;
         case Power::PowerShutdown:
-            command = "canPowerOff";
+            command = QL1S("canPowerOff");
             break;
         default:
             return false;
     }
 
     // there can be case when lxqtsession-session does not run
-    return dbusCall(LXQT_SERVICE, LXQT_PATH, LXQT_SERVICE,
+    return dbusCall(QL1S(LXQT_SERVICE), QL1S(LXQT_PATH), QL1S(LXQT_SERVICE),
             QDBusConnection::sessionBus(), command,
             PowerProvider::DontCheckDBUS);
 }
@@ -529,21 +529,21 @@ bool LXQtProvider::doAction(Power::Action action)
     switch (action)
     {
         case Power::PowerLogout:
-            command = "logout";
+            command = QL1S("logout");
             break;
         case Power::PowerReboot:
-            command = "reboot";
+            command = QL1S("reboot");
             break;
         case Power::PowerShutdown:
-            command = "powerOff";
+            command = QL1S("powerOff");
             break;
         default:
             return false;
     }
 
-    return dbusCall(LXQT_SERVICE,
-             LXQT_PATH,
-             LXQT_INTERFACE,
+    return dbusCall(QL1S(LXQT_SERVICE),
+             QL1S(LXQT_PATH),
+             QL1S(LXQT_INTERFACE),
              QDBusConnection::sessionBus(),
              command
             );
@@ -625,7 +625,7 @@ bool HalProvider::doAction(Power::Action action)
  ************************************************/
 CustomProvider::CustomProvider(QObject *parent):
     PowerProvider(parent),
-    mSettings("power")
+    mSettings(QL1S("power"))
 {
 }
 
@@ -638,22 +638,22 @@ bool CustomProvider::canAction(Power::Action action) const
     switch (action)
     {
     case Power::PowerShutdown:
-        return mSettings.contains("shutdownCommand");
+        return mSettings.contains(QL1S("shutdownCommand"));
 
     case Power::PowerReboot:
-        return mSettings.contains("rebootCommand");
+        return mSettings.contains(QL1S("rebootCommand"));
 
     case Power::PowerHibernate:
-        return mSettings.contains("hibernateCommand");
+        return mSettings.contains(QL1S("hibernateCommand"));
 
     case Power::PowerSuspend:
-        return mSettings.contains("suspendCommand");
+        return mSettings.contains(QL1S("suspendCommand"));
 
     case Power::PowerLogout:
-        return mSettings.contains("logoutCommand");
+        return mSettings.contains(QL1S("logoutCommand"));
 
     case Power::PowerMonitorOff:
-        return mSettings.contains("monitorOffCommand");
+        return mSettings.contains(QL1S("monitorOffCommand"));
 
     default:
         return false;
@@ -667,27 +667,27 @@ bool CustomProvider::doAction(Power::Action action)
     switch(action)
     {
     case Power::PowerShutdown:
-        command = mSettings.value("shutdownCommand").toString();
+        command = mSettings.value(QL1S("shutdownCommand")).toString();
         break;
 
     case Power::PowerReboot:
-        command = mSettings.value("rebootCommand").toString();
+        command = mSettings.value(QL1S("rebootCommand")).toString();
         break;
 
     case Power::PowerHibernate:
-        command = mSettings.value("hibernateCommand").toString();
+        command = mSettings.value(QL1S("hibernateCommand")).toString();
         break;
 
     case Power::PowerSuspend:
-        command = mSettings.value("suspendCommand").toString();
+        command = mSettings.value(QL1S("suspendCommand")).toString();
         break;
 
     case Power::PowerLogout:
-        command = mSettings.value("logoutCommand").toString();
+        command = mSettings.value(QL1S("logoutCommand")).toString();
         break;
 
     case Power::PowerMonitorOff:
-        command = mSettings.value("monitorOffCommand").toString();
+        command = mSettings.value(QL1S("monitorOffCommand")).toString();
         break;
 
     default:

--- a/lxqtpowermanager.cpp
+++ b/lxqtpowermanager.cpp
@@ -96,9 +96,9 @@ PowerManager::PowerManager(QObject * parent, bool skipWarning)
 //    connect(m_power, SIGNAL(monitoring(const QString &)),
 //            this, SLOT(monitoring(const QString&)));
 
-    QString sessionConfig(getenv("LXQT_SESSION_CONFIG"));
-    Settings settings(sessionConfig.isEmpty() ? "session" : sessionConfig);
-    m_skipWarning = settings.value("leave_confirmation").toBool() ? false : true;
+    QString sessionConfig(QFile::decodeName(qgetenv("LXQT_SESSION_CONFIG")));
+    Settings settings(sessionConfig.isEmpty() ? QL1S("session") : sessionConfig);
+    m_skipWarning = settings.value(QL1S("leave_confirmation")).toBool() ? false : true;
 }
 
 PowerManager::~PowerManager()
@@ -114,35 +114,35 @@ QList<QAction*> PowerManager::availableActions()
     // TODO/FIXME: icons
     if (m_power->canHibernate())
     {
-        act = new QAction(XdgIcon::fromTheme("system-suspend-hibernate"), tr("Hibernate"), this);
+        act = new QAction(XdgIcon::fromTheme(QL1S("system-suspend-hibernate")), tr("Hibernate"), this);
         connect(act, &QAction::triggered, this, &PowerManager::hibernate);
         ret.append(act);
     }
 
     if (m_power->canSuspend())
     {
-        act = new QAction(XdgIcon::fromTheme("system-suspend"), tr("Suspend"), this);
+        act = new QAction(XdgIcon::fromTheme(QL1S("system-suspend")), tr("Suspend"), this);
         connect(act, &QAction::triggered, this, &PowerManager::suspend);
         ret.append(act);
     }
 
     if (m_power->canReboot())
     {
-        act = new QAction(XdgIcon::fromTheme("system-reboot"), tr("Reboot"), this);
+        act = new QAction(XdgIcon::fromTheme(QL1S("system-reboot")), tr("Reboot"), this);
         connect(act, &QAction::triggered, this, &PowerManager::reboot);
         ret.append(act);
     }
 
     if (m_power->canShutdown())
     {
-        act = new QAction(XdgIcon::fromTheme("system-shutdown"), tr("Shutdown"), this);
+        act = new QAction(XdgIcon::fromTheme(QL1S("system-shutdown")), tr("Shutdown"), this);
         connect(act, &QAction::triggered, this, &PowerManager::shutdown);
         ret.append(act);
     }
 
     if (m_power->canLogout())
     {
-        act = new QAction(XdgIcon::fromTheme("system-log-out"), tr("Logout"), this);
+        act = new QAction(XdgIcon::fromTheme(QL1S("system-log-out")), tr("Logout"), this);
         connect(act, &QAction::triggered, this, &PowerManager::logout);
         ret.append(act);
     }

--- a/lxqtprogramfinder.cpp
+++ b/lxqtprogramfinder.cpp
@@ -32,14 +32,14 @@ using namespace LXQt;
 LXQT_API bool ProgramFinder::programExists(const QString& command)
 {
     const QString program = programName(command);
-    if (program[0] == QChar('/'))
+    if (program[0] == QL1C('/'))
     {
         QFileInfo fi(program);
         return fi.isExecutable() && fi.isFile();
     }
 
-    const QString path = qgetenv("PATH");
-    const QStringList dirs = path.split(":", QString::SkipEmptyParts);
+    const QString path = QFile::decodeName(qgetenv("PATH"));
+    const QStringList dirs = path.split(QL1C(':'), QString::SkipEmptyParts);
     for (const QString& dirName : dirs)
     {
         const QFileInfo fi(QDir(dirName), program);
@@ -63,6 +63,6 @@ LXQT_API QString ProgramFinder::programName(const QString& command)
     wordexp_t we;
     if (wordexp(command.toLocal8Bit().constData(), &we, WRDE_NOCMD) == 0)
         if (we.we_wordc > 0)
-            return QString(we.we_wordv[0]);
+            return QString::fromLocal8Bit(we.we_wordv[0]);
     return QString();
 }

--- a/lxqtscreensaver.cpp
+++ b/lxqtscreensaver.cpp
@@ -233,7 +233,7 @@ QList<QAction*> ScreenSaver::availableActions()
     QList<QAction*> ret;
     QAction * act;
 
-    act = new QAction(XdgIcon::fromTheme("system-lock-screen", "lock"), tr("Lock Screen"), this);
+    act = new QAction(XdgIcon::fromTheme(QL1S("system-lock-screen"), QL1S("lock")), tr("Lock Screen"), this);
     connect(act, &QAction::triggered, this, &ScreenSaver::lockScreen);
     ret.append(act);
 
@@ -244,7 +244,7 @@ void ScreenSaver::lockScreen()
 {
     Q_D(ScreenSaver);
     if (!d->isScreenSaverLocked())
-        d->m_xdgProcess->start("xdg-screensaver", QStringList() << "lock");
+        d->m_xdgProcess->start(QL1S("xdg-screensaver"), QStringList() << QL1S("lock"));
 }
 
 } // namespace LXQt

--- a/lxqtsettings.cpp
+++ b/lxqtsettings.cpp
@@ -54,9 +54,9 @@ public:
     {
         // HACK: we need to ensure that the user (~/.config/lxqt/<module>.conf)
         //       exists to have functional mWatcher
-        if (!mParent->contains("__userfile__"))
+        if (!mParent->contains(QL1S("__userfile__")))
         {
-            mParent->setValue("__userfile__", true);
+            mParent->setValue(QL1S("__userfile__"), true);
 #if defined(WITH_XDG_DIRS_FALLBACK)
             if (useXdgFallback)
             {
@@ -145,7 +145,7 @@ public:
 
  ************************************************/
 Settings::Settings(const QString& module, QObject* parent) :
-    QSettings("lxqt", module, parent),
+    QSettings(QL1S("lxqt"), module, parent),
     d_ptr(new SettingsPrivate(this, true))
 {
 }
@@ -310,25 +310,25 @@ const GlobalSettings *Settings::globalSettings()
 QString SettingsPrivate::localizedKey(const QString& key) const
 {
 
-    QString lang = getenv("LC_MESSAGES");
+    QString lang = QString::fromLocal8Bit(qgetenv("LC_MESSAGES"));
 
     if (lang.isEmpty())
-        lang = getenv("LC_ALL");
+        lang = QString::fromLocal8Bit(qgetenv("LC_ALL"));
 
     if (lang.isEmpty())
-         lang = getenv("LANG");
+         lang = QString::fromLocal8Bit(qgetenv("LANG"));
 
 
-    QString modifier = lang.section('@', 1);
+    QString modifier = lang.section(QL1C('@'), 1);
     if (!modifier.isEmpty())
         lang.truncate(lang.length() - modifier.length() - 1);
 
-    QString encoding = lang.section('.', 1);
+    QString encoding = lang.section(QL1C('.'), 1);
     if (!encoding.isEmpty())
         lang.truncate(lang.length() - encoding.length() - 1);
 
 
-    QString country = lang.section('_', 1);
+    QString country = lang.section(QL1C('_'), 1);
     if (!country.isEmpty())
         lang.truncate(lang.length() - country.length() - 1);
 
@@ -342,7 +342,7 @@ QString SettingsPrivate::localizedKey(const QString& key) const
 
     if (!modifier.isEmpty() && !country.isEmpty())
     {
-        QString k = QString("%1[%2_%3@%4]").arg(key, lang, country, modifier);
+        QString k = QString::fromLatin1("%1[%2_%3@%4]").arg(key, lang, country, modifier);
         //qDebug() << "\t try " << k << mParent->contains(k);
         if (mParent->contains(k))
             return k;
@@ -350,7 +350,7 @@ QString SettingsPrivate::localizedKey(const QString& key) const
 
     if (!country.isEmpty())
     {
-        QString k = QString("%1[%2_%3]").arg(key, lang, country);
+        QString k = QString::fromLatin1("%1[%2_%3]").arg(key, lang, country);
         //qDebug() << "\t try " << k  << mParent->contains(k);
         if (mParent->contains(k))
             return k;
@@ -358,13 +358,13 @@ QString SettingsPrivate::localizedKey(const QString& key) const
 
     if (!modifier.isEmpty())
     {
-        QString k = QString("%1[%2@%3]").arg(key, lang, modifier);
+        QString k = QString::fromLatin1("%1[%2@%3]").arg(key, lang, modifier);
         //qDebug() << "\t try " << k  << mParent->contains(k);
         if (mParent->contains(k))
             return k;
     }
 
-    QString k = QString("%1[%2]").arg(key, lang);
+    QString k = QString::fromLatin1("%1[%2]").arg(key, lang);
     //qDebug() << "\t try " << k  << mParent->contains(k);
     if (mParent->contains(k))
         return k;
@@ -426,8 +426,8 @@ LXQtTheme::LXQtTheme(const QString &path):
         d->mValid = !(d->mPath.isEmpty());
     }
 
-    if (QDir(path).exists("preview.png"))
-        d->mPreviewImg = path + "/preview.png";
+    if (QDir(path).exists(QL1S("preview.png")))
+        d->mPreviewImg = path + QL1S("/preview.png");
 }
 
 
@@ -450,7 +450,7 @@ QString LXQtThemeData::findTheme(const QString &themeName)
 
     for(const QString &path : qAsConst(paths))
     {
-        QDir dir(QString("%1/lxqt/themes/%2").arg(path, themeName));
+        QDir dir(QString::fromLatin1("%1/lxqt/themes/%2").arg(path, themeName));
         if (dir.isReadable())
             return dir.absolutePath();
     }
@@ -541,7 +541,7 @@ QString LXQtThemeData::loadQss(const QString& qssFile) const
         return QString();
     }
 
-    QString qss = f.readAll();
+    QString qss = QString::fromLocal8Bit(f.readAll());
     f.close();
 
     if (qss.isEmpty())
@@ -549,7 +549,7 @@ QString LXQtThemeData::loadQss(const QString& qssFile) const
 
     // handle relative paths
     QString qssDir = QFileInfo(qssFile).canonicalPath();
-    qss.replace(QRegExp("url.[ \\t\\s]*", Qt::CaseInsensitive, QRegExp::RegExp2), "url(" + qssDir + "/");
+    qss.replace(QRegExp(QL1S("url.[ \\t\\s]*"), Qt::CaseInsensitive, QRegExp::RegExp2), QL1S("url(") + qssDir + QL1C('/'));
 
     return qss;
 }
@@ -560,7 +560,7 @@ QString LXQtThemeData::loadQss(const QString& qssFile) const
  ************************************************/
 QString LXQtTheme::desktopBackground(int screen) const
 {
-    QString wallpaperCfgFileName = QString("%1/wallpaper.cfg").arg(d->mPath);
+    QString wallpaperCfgFileName = QString::fromLatin1("%1/wallpaper.cfg").arg(d->mPath);
 
     if (wallpaperCfgFileName.isEmpty())
         return QString();
@@ -569,15 +569,15 @@ QString LXQtTheme::desktopBackground(int screen) const
     QString themeDir = QFileInfo(wallpaperCfgFileName).absolutePath();
     // There is something strange... If I remove next line the wallpapers array is not found...
     s.childKeys();
-    s.beginReadArray("wallpapers");
+    s.beginReadArray(QL1S("wallpapers"));
 
     s.setArrayIndex(screen - 1);
-    if (s.contains("file"))
-        return QString("%1/%2").arg(themeDir, s.value("file").toString());
+    if (s.contains(QL1S("file")))
+        return QString::fromLatin1("%1/%2").arg(themeDir, s.value(QL1S("file")).toString());
 
     s.setArrayIndex(0);
-    if (s.contains("file"))
-        return QString("%1/%2").arg(themeDir, s.value("file").toString());
+    if (s.contains(QL1S("file")))
+        return QString::fromLatin1("%1/%2").arg(themeDir, s.value(QL1S("file")).toString());
 
     return QString();
 }
@@ -589,7 +589,7 @@ QString LXQtTheme::desktopBackground(int screen) const
 const LXQtTheme &LXQtTheme::currentTheme()
 {
     static LXQtTheme theme;
-    QString name = Settings::globalSettings()->value("theme").toString();
+    QString name = Settings::globalSettings()->value(QL1S("theme")).toString();
     if (theme.name() != name)
     {
         theme = LXQtTheme(name);
@@ -612,13 +612,13 @@ QList<LXQtTheme> LXQtTheme::allThemes()
 
     for(const QString &path : qAsConst(paths))
     {
-        QDir dir(QString("%1/lxqt/themes").arg(path));
+        QDir dir(QString::fromLatin1("%1/lxqt/themes").arg(path));
         const QFileInfoList dirs = dir.entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot);
 
         for(const QFileInfo &dir : dirs)
         {
             if (!processed.contains(dir.fileName()) &&
-                 QDir(dir.absoluteFilePath()).exists("lxqt-panel.qss"))
+                 QDir(dir.absoluteFilePath()).exists(QL1S("lxqt-panel.qss")))
             {
                 processed << dir.fileName();
                 ret << LXQtTheme(dir.absoluteFilePath());
@@ -686,10 +686,10 @@ void SettingsCache::loadToSettings()
 
  ************************************************/
 GlobalSettings::GlobalSettings():
-    Settings("lxqt"),
+    Settings(QL1S("lxqt")),
     d_ptr(new GlobalSettingsPrivate(this))
 {
-    if (value("icon_theme").toString().isEmpty())
+    if (value(QL1S("icon_theme")).toString().isEmpty())
     {
         qWarning() << QString::fromLatin1("Icon Theme not set. Fallbacking to Oxygen, if installed");
         const QString fallback(QLatin1String("oxygen"));
@@ -697,7 +697,7 @@ GlobalSettings::GlobalSettings():
         const QDir dir(QLatin1String(LXQT_DATA_DIR) + QLatin1String("/icons"));
         if (dir.exists(fallback))
         {
-            setValue("icon_theme", fallback);
+            setValue(QL1S("icon_theme"), fallback);
             sync();
         }
         else
@@ -724,14 +724,14 @@ void GlobalSettings::fileChanged()
     sync();
 
 
-    QString it = value("icon_theme").toString();
+    QString it = value(QL1S("icon_theme")).toString();
     if (d->mIconTheme != it)
     {
         emit iconThemeChanged();
     }
 
-    QString rt = value("theme").toString();
-    qlonglong themeUpdated = value("__theme_updated__").toLongLong();
+    QString rt = value(QL1S("theme")).toString();
+    qlonglong themeUpdated = value(QL1S("__theme_updated__")).toLongLong();
     if ((d->mLXQtTheme != rt) || (d->mThemeUpdated != themeUpdated))
     {
         d->mLXQtTheme = rt;

--- a/lxqttranslator.cpp
+++ b/lxqttranslator.cpp
@@ -51,8 +51,8 @@ QStringList *getSearchPaths()
     if (searchPath == 0)
     {
         searchPath = new QStringList();
-        *searchPath << XdgDirs::dataDirs(QLatin1Char('/') % LXQT_RELATIVE_SHARE_TRANSLATIONS_DIR);
-        *searchPath << QString(LXQT_SHARE_TRANSLATIONS_DIR);
+        *searchPath << XdgDirs::dataDirs(QL1C('/') + QL1S(LXQT_RELATIVE_SHARE_TRANSLATIONS_DIR));
+        *searchPath << QL1S(LXQT_SHARE_TRANSLATIONS_DIR);
         searchPath->removeDuplicates();
     }
 
@@ -95,17 +95,17 @@ bool translate(const QString &name, const QString &owner)
 
         if (!owner.isEmpty())
         {
-            subPaths << path % QChar('/') % owner % QChar('/') % name;
+            subPaths << path + QL1C('/') + owner + QL1C('/') + name;
         }
         else
         {
-            subPaths << path % QChar('/') % name;
+            subPaths << path + QL1C('/') + name;
             subPaths << path;
         }
 
         for(const QString &p : qAsConst(subPaths))
         {
-            if (appTranslator->load(name + "_" + locale, p))
+            if (appTranslator->load(name + QL1C('_') + locale, p))
             {
                 QCoreApplication::installTranslator(appTranslator);
                 return true;
@@ -135,7 +135,7 @@ bool Translator::translateApplication(const QString &applicationName)
     const QString locale = QLocale::system().name();
     QTranslator *qtTranslator = new QTranslator(qApp);
 
-    if (qtTranslator->load("qt_" + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+    if (qtTranslator->load(QL1S("qt_") + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
     {
         qApp->installTranslator(qtTranslator);
     }
@@ -170,7 +170,7 @@ bool Translator::translatePlugin(const QString &pluginName, const QString& type)
 {
     static QSet<QString> loadedPlugins;
 
-    const QString fullName = type % QChar('/') % pluginName;
+    const QString fullName = type % QL1C('/') % pluginName;
     if (loadedPlugins.contains(fullName))
         return true;
 


### PR DESCRIPTION
Disables automatic conversions from 8-bit strings (char *) to unicode
QStrings.
Disables automatic conversion from QString to 8-bit strings (char *).
Disables automatic conversions from QByteArray to const char * or const
void *.
Disables automatic conversions from QString (or char *) to QUrl.
Use QStringBuilder for more efficient string creation.

It make us aware of string and encoding conversions.