### PR TITLE
Removes local compile definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,6 @@ target_compile_definitions(${LXQT_LIBRARY_NAME}
         "LXQT_INSTALL_PREFIX=\"${CMAKE_INSTALL_PREFIX}\""
         "LXQT_VERSION=\"${LXQT_VERSION}\""
         "COMPILE_LIBLXQT"
-        "QT_NO_FOREACH"
         "QT_USE_QSTRINGBUILDER"
         "QT_NO_CAST_FROM_ASCII"
         "QT_NO_CAST_TO_ASCII"


### PR DESCRIPTION
QT_NO_FOREACH is already part of LXQtCompilerSettings CMake module.