### PR TITLE
lxqtnotification: async API for querying serverInfo

### DIFF
--- a/lxqtnotification.h
+++ b/lxqtnotification.h
@@ -143,8 +143,20 @@ public:
 
     /*!
      * \brief Returns information about the notifications server
+     * \note This call may block for up to 25s (default dbus timeout) if the notification server
+     *       is not running and the info wasn't previously queried.
+     * \sa queryServerInfo()
      */
     const ServerInfo serverInfo();
+
+    /*!
+     * \brief Performs an asyncronous query of the notifications server information.
+     *        Use serverInfoReady signal to get notified (no pun intended) when the
+     *        info will be received.
+     * \sa serverInfo()
+     * \sa serverInfoReady()
+     */
+    void queryServerInfo();
 
     /*!
      * \brief Convenience function to create and display a notification for the most common
@@ -183,6 +195,12 @@ Q_SIGNALS:
      * \sa setActions()
      */
     void actionActivated(int actionNumber);
+
+    /*!
+     * \brief Emitted when queried server info is received
+     * \sa queryServerInfo()
+     */
+    void serverInfoReady();
 
 private:
     Q_DECLARE_PRIVATE(Notification)

--- a/lxqtnotification_p.h
+++ b/lxqtnotification_p.h
@@ -42,6 +42,7 @@ public:
     void close();
     void setActions(QStringList actions, int defaultAction);
     const Notification::ServerInfo serverInfo();
+    void queryServerInfo(bool async=1);
 
 public Q_SLOTS:
     void handleAction(uint id, QString key);
@@ -58,6 +59,9 @@ private:
     QVariantMap mHints;
     int mDefaultAction;
     int mTimeout;
+
+    static Notification::ServerInfo sServerInfo;
+    static bool sIsServerInfoQuried;
 
     Notification* const q_ptr;
     Q_DECLARE_PUBLIC(Notification)


### PR DESCRIPTION
Adds an asynchronous version of Notification::serverInfo() call which
will not hang up app for a while if there is no daemon running.