### PR TITLE
Enable/disable a standard button if it exists

### DIFF
--- a/configdialog/lxqtconfigdialog.cpp
+++ b/configdialog/lxqtconfigdialog.cpp
@@ -103,6 +103,13 @@ void ConfigDialog::setButtons(QDialogButtonBox::StandardButtons buttons)
         button->setAutoDefault(false);
 }
 
+void ConfigDialog::enableButton(QDialogButtonBox::StandardButton which, bool enable)
+{
+    Q_D(ConfigDialog);
+    if (QPushButton* pb = d->ui->buttons->button(which))
+        pb->setEnabled(enable);
+}
+
 void ConfigDialog::addPage(QWidget* page, const QString& name, const QString& iconName)
 {
     addPage(page, name, QStringList() << iconName);

--- a/configdialog/lxqtconfigdialog.h
+++ b/configdialog/lxqtconfigdialog.h
@@ -56,6 +56,11 @@ public:
     void setButtons(QDialogButtonBox::StandardButtons buttons);
 
     /*!
+     * Enable/disable a standard button if it exists
+     */
+    void enableButton(QDialogButtonBox::StandardButton which, bool enable);
+
+    /*!
      * Add a page to the configure dialog
      */
     void addPage(QWidget* page, const QString& name, const QString& iconName = QLatin1String("application-x-executable"));


### PR DESCRIPTION
This is needed for adding Apply button later because Apply button should be enabled/disabled appropriately. Of course, it might find other usages too.