### PR TITLE
Fix licenses

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,7 +6,5 @@ Copyright:
     Copyright (c) 2010-2012 Razor team
     Copyright (c) 2012-2018 LXQt team
 
-License: LGPL-2.1+ and BSD-3-clause
+License: LGPL-2.1+
 The full text of the LGPL-2.1+ licenses can be found in the 'COPYING' file.
-The full text of the BSD-3-clause license can be found in the headers of
-the files under this license.


### PR DESCRIPTION
In https://github.com/lxqt/liblxqt/pull/66:

> some files in cmake/modules are under BSD-3-clause

Looks like those CMake files are removed after liblxqt moved to lxqt-build-tools https://github.com/lxqt/liblxqt/pull/109.