### PR TITLE
Set default button to Yes in leave dialogs

### DIFF
--- a/lxqtpowermanager.cpp
+++ b/lxqtpowermanager.cpp
@@ -62,6 +62,7 @@ public:
         msgBox.setWindowTitle(title);
         msgBox.setText(text);
         msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        msgBox.setDefaultButton(QMessageBox::Yes);
 
         return (msgBox.exec() == QMessageBox::Yes);
     }


### PR DESCRIPTION
Because, otherwise, it'll be "No" with Gnome button layout, which is a valid layout in Qt and can be used anywhere.

Fixes https://github.com/lxqt/lxqt-session/issues/249