### PR TITLE
Set size hint of selection widget correctly

### DIFF
--- a/configdialog/lxqtpageselectwidget.cpp
+++ b/configdialog/lxqtpageselectwidget.cpp
@@ -143,9 +143,23 @@ QSize PageSelectWidget::viewportSizeHint() const
 {
     const int spacing2 = spacing() * 2;
     QSize size{sizeHintForColumn(0) + spacing2, (sizeHintForRow(0) + spacing2) * count()};
-    if (verticalScrollBar()->isVisible())
+    auto vScrollbar = verticalScrollBar();
+    if (vScrollbar
+        && vScrollbar->isVisible()
+        && !vScrollbar->style()->styleHint(QStyle::SH_ScrollBar_Transient, nullptr, vScrollbar))
+    {
         size.rwidth() += verticalScrollBar()->sizeHint().width();
+    }
     return size;
+}
+
+/************************************************
+
+ ************************************************/
+QSize PageSelectWidget::sizeHint() const
+{
+    const int f = 2 * frameWidth();
+    return viewportSizeHint() + QSize(f, f);
 }
 
 /************************************************

--- a/configdialog/lxqtpageselectwidget.h
+++ b/configdialog/lxqtpageselectwidget.h
@@ -50,6 +50,7 @@ public:
 
 protected:
     QSize viewportSizeHint() const override;
+    QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
 
 protected slots:


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt-config/issues/499

We just need to add twice the frame width to the viewport size hint because we've added the scrollbar thickness in `PageSelectWidget::viewportSizeHint`.

Also, transient scrollbars are taken into account — believe me, they exist ;) and they should have been taken into account by Qt in the first place (= Qt bug).