### PR TITLE
Fix compilation error on Debian GNU/Hurd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,9 @@ message(STATUS "Building ${PROJECT_NAME} with Qt ${Qt5Core_VERSION}")
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs) # Standard directories for installation
 
-add_subdirectory(lxqtbacklight/linux_backend/driver)
+if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
+    add_subdirectory(lxqtbacklight/linux_backend/driver)
+endif (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
 
 set(LXQT_PKG_CONFIG_DESCRIPTION "Shared library for LXQt applications")
 
@@ -136,7 +138,6 @@ set(SRCS
     lxqtrotatedwidget.cpp
     lxqtbacklight.cpp
     lxqtbacklight/virtual_backend.cpp
-    lxqtbacklight/linux_backend/linuxbackend.cpp
 )
 
 if (NOT APPLE)
@@ -144,6 +145,12 @@ if (NOT APPLE)
         lxqtscreensaver.cpp
     )
 endif (NOT APPLE)
+
+if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
+    list (APPEND SRCS
+        lxqtbacklight/linux_backend/linuxbackend.cpp
+    )
+endif (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
 
 set(MOCS
     lxqthtmldelegate.h
@@ -163,7 +170,6 @@ set(MOCS
     lxqtgridlayout.h
     lxqtrotatedwidget.h
     lxqtbacklight/virtual_backend.h
-    lxqtbacklight/linux_backend/linuxbackend.h
 )
 
 if (NOT APPLE)
@@ -171,6 +177,12 @@ if (NOT APPLE)
         lxqtscreensaver.h
     )
 endif (NOT APPLE)
+
+if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
+    list (APPEND SRCS
+        lxqtbacklight/linux_backend/linuxbackend.h
+    )
+endif (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
 
 set(FORMS
     configdialog/lxqtconfigdialog.ui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,9 @@ find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5 ${QT_MINIMUM_VERSION} CONFIG REQUIRED Widgets DBus LinguistTools)
 find_package(Qt5Xdg ${QTXDG_MINIMUM_VERSION} REQUIRED)
 find_package(KF5WindowSystem ${KF5_MINIMUM_VERSION} REQUIRED)
-find_package(PolkitQt5-1 REQUIRED)
+if (BUILD_BACKLIGHT_LINUX_BACKEND)
+    find_package(PolkitQt5-1 REQUIRED)
+endif (BUILD_BACKLIGHT_LINUX_BACKEND)
 if (NOT APPLE)
     find_package(Qt5 ${QT_MINIMUM_VERSION} CONFIG REQUIRED X11Extras)
     find_package(X11 REQUIRED)
@@ -409,7 +411,9 @@ install(FILES ${LXQT_CONFIG_FILES}
     COMPONENT Runtime
 )
 
-install(FILES ${POLKIT_FILES} DESTINATION "${POLKITQT-1_POLICY_FILES_INSTALL_DIR}")
+if (BUILD_BACKLIGHT_LINUX_BACKEND)
+    install(FILES ${POLKIT_FILES} DESTINATION "${POLKITQT-1_POLICY_FILES_INSTALL_DIR}")
+endif (BUILD_BACKLIGHT_LINUX_BACKEND)
 
 #************************************************
 # Create and install pkgconfig file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LXQT_VERSION ${LXQT_MAJOR_VERSION}.${LXQT_MINOR_VERSION}.${LXQT_PATCH_VERSIO
 
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
+option(BUILD_BACKLIGHT_LINUX_BACKEND "Build the Linux backend for the backlight" ON)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -51,9 +52,10 @@ message(STATUS "Building ${PROJECT_NAME} with Qt ${Qt5Core_VERSION}")
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs) # Standard directories for installation
 
-if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
+if (BUILD_BACKLIGHT_LINUX_BACKEND)
     add_subdirectory(lxqtbacklight/linux_backend/driver)
-endif (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
+    add_definitions(-DUSE_BACKLIGHT_LINUX_BACKEND)
+endif (BUILD_BACKLIGHT_LINUX_BACKEND)
 
 set(LXQT_PKG_CONFIG_DESCRIPTION "Shared library for LXQt applications")
 
@@ -146,11 +148,11 @@ if (NOT APPLE)
     )
 endif (NOT APPLE)
 
-if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
+if (BUILD_BACKLIGHT_LINUX_BACKEND)
     list (APPEND SRCS
         lxqtbacklight/linux_backend/linuxbackend.cpp
     )
-endif (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
+endif (BUILD_BACKLIGHT_LINUX_BACKEND)
 
 set(MOCS
     lxqthtmldelegate.h
@@ -178,11 +180,11 @@ if (NOT APPLE)
     )
 endif (NOT APPLE)
 
-if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
+if (BUILD_BACKLIGHT_LINUX_BACKEND)
     list (APPEND SRCS
         lxqtbacklight/linux_backend/linuxbackend.h
     )
-endif (NOT (${CMAKE_SYSTEM_NAME} STREQUAL GNU))
+endif (BUILD_BACKLIGHT_LINUX_BACKEND)
 
 set(FORMS
     configdialog/lxqtconfigdialog.ui

--- a/lxqtbacklight.cpp
+++ b/lxqtbacklight.cpp
@@ -18,13 +18,19 @@
 
 #include "lxqtbacklight.h"
 #include "lxqtbacklight/virtual_backend.h"
-#include "lxqtbacklight/linux_backend/linuxbackend.h"
+#ifndef Q_OS_HURD
+    #include "lxqtbacklight/linux_backend/linuxbackend.h"
+#endif
 
 namespace LXQt {
 
 Backlight::Backlight(QObject *parent):QObject(parent)
 {
+#ifndef Q_OS_HURD
     m_backend = (VirtualBackEnd *) new LinuxBackend(this);
+#else
+    m_backend = new VirtualBackEnd(this);
+#endif
     connect(m_backend, &VirtualBackEnd::backlightChanged, this, &Backlight::backlightChangedSlot);
 }
 

--- a/lxqtbacklight.cpp
+++ b/lxqtbacklight.cpp
@@ -18,7 +18,7 @@
 
 #include "lxqtbacklight.h"
 #include "lxqtbacklight/virtual_backend.h"
-#ifndef Q_OS_HURD
+#ifdef USE_BACKLIGHT_LINUX_BACKEND
     #include "lxqtbacklight/linux_backend/linuxbackend.h"
 #endif
 
@@ -26,7 +26,7 @@ namespace LXQt {
 
 Backlight::Backlight(QObject *parent):QObject(parent)
 {
-#ifndef Q_OS_HURD
+#ifdef USE_BACKLIGHT_LINUX_BACKEND
     m_backend = (VirtualBackEnd *) new LinuxBackend(this);
 #else
     m_backend = new VirtualBackEnd(this);


### PR DESCRIPTION
Changes:
- Do not compile the linux backend for the backlight driver on the Hurd.

Justification:
- Fails to compile on the Hurd (`PATH_MAX` is not defined on the Hurd)
- The backend uses the `/sys/` special file system, which is not provided by the Hurd.

Alternative approach:
- Modify `open_driver_file` in [`lxqtbacklight/linux_backend/driver/libbacklight_backend.c`](https://github.com/lxqt/liblxqt/blob/2b805344d81362237a21dcbed097f2fdd36cb4a4/lxqtbacklight/linux_backend/driver/libbacklight_backend.c) to not use `PATH_MAX`.