### PR TITLE
PowerManager: correct dialog location

### DIFF
--- a/lxqtpowermanager.cpp
+++ b/lxqtpowermanager.cpp
@@ -75,18 +75,6 @@ public:
         Q_UNUSED(text)
         QMessageBox::warning(parentWidget(), tr("LXQt Power Manager Error"), tr("Hibernate failed."));
     }
-
-
-protected:
-    void resizeEvent(QResizeEvent* event) override
-    {
-        Q_UNUSED(event)
-        const QScreen *primaryScreen = QGuiApplication::primaryScreen();
-        const QRect screen = primaryScreen ? primaryScreen->geometry() : QRect();
-        move((screen.width()  - this->width()) / 2,
-             (screen.height() - this->height()) / 2);
-
-    }
 };
 
 PowerManager::PowerManager(QObject * parent, bool skipWarning)


### PR DESCRIPTION
Dialog show up in weird place on multi monitor environment.
Current code (wrongly) adjust dialog's geometry in various location. But
in fact these code aren't necessary because QDialog automatically move
dialog to center of the screen. It also do the right thing on multiple
monitor environment (center dialog on monitor that the mouse cursor
currently is in).