### PR TITLE
LXQtTheme: Handle self assignment properly

### DIFF
--- a/lxqtsettings.cpp
+++ b/lxqtsettings.cpp
@@ -446,7 +446,9 @@ LXQtTheme::~LXQtTheme()
  ************************************************/
 LXQtTheme& LXQtTheme::operator=(const LXQtTheme &other)
 {
-    d = other.d;
+    if (this != &other)
+        d = other.d;
+
     return *this;
 }
 


### PR DESCRIPTION
Copy assignment operators must be protected against self-assignment.
Good practice.