### PR TITLE
Fix dbus errors with invalid QVariant data sent over it

### DIFF
--- a/lxqtpower/lxqtpowerproviders.cpp
+++ b/lxqtpower/lxqtpowerproviders.cpp
@@ -141,7 +141,7 @@ static bool dbusCallSystemd(const QString &service,
         return false;
     }
 
-    QDBusMessage msg = dbus.call(method, needBoolArg ? QVariant(true) : QVariant());
+    QDBusMessage msg = needBoolArg ? dbus.call(method, QVariant(true)) : dbus.call(method);
 
     if (!msg.errorName().isEmpty())
     {


### PR DESCRIPTION
Sending invalid QVariant over dbus let systemd provider to fail retrieving informations. journalctl list warnings on that calls. This (easy) patch solves this.