### PR TITLE
lxqtsettings: Make GlobalSettings public (export symbols)

### DIFF
--- a/lxqtsettings.h
+++ b/lxqtsettings.h
@@ -191,7 +191,7 @@ private:
 
 class GlobalSettingsPrivate;
 
-class GlobalSettings: public Settings
+class LXQT_API GlobalSettings : public Settings
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
..to make it possible to use new Qt5(onwards) signal/slot syntax.

Note: needed for e.g. lxqt/lxqt-powermanagement#227