### PR TITLE
Fixed loading of cached settings

### DIFF
--- a/lxqtsettings.cpp
+++ b/lxqtsettings.cpp
@@ -621,6 +621,7 @@ SettingsCache::SettingsCache(QSettings *settings) :
  ************************************************/
 void SettingsCache::loadFromSettings()
 {
+    mCache.clear();
     const QStringList keys = mSettings.allKeys();
 
     const int N = keys.size();


### PR DESCRIPTION
The bug especially showed up in lxqt-panel: after resetting its config dialogs, it made a mess out of Panel's config file.