### PR TITLE
Guarantee that theme name is name of theme folder

### DIFF
--- a/lxqtsettings.cpp
+++ b/lxqtsettings.cpp
@@ -422,6 +422,7 @@ QString LXQtThemeData::findTheme(const QString &themeName)
             if (QString::compare(dir.fileName(), themeName, Qt::CaseInsensitive) == 0 &&
                 QDir(dir.absoluteFilePath()).exists(QL1S("lxqt-panel.qss")))
             {
+                mName = dir.fileName(); // correct the name too
                 return dir.absoluteFilePath();
             }
         }


### PR DESCRIPTION
It wasn't guaranteed after considering theme names case-insensitively (→ https://github.com/lxqt/liblxqt/pull/308).

After this change, other components won't need to be aware of case-insensitivity of theme names.