### PR TITLE
Reversed case-insensitivity commit

### DIFF
--- a/lxqtsettings.cpp
+++ b/lxqtsettings.cpp
@@ -415,16 +415,9 @@ QString LXQtThemeData::findTheme(const QString &themeName)
 
     for(const QString &path : qAsConst(paths))
     {
-        QDir dir(QString::fromLatin1("%1/lxqt/themes").arg(path));
-        const QFileInfoList dirs = dir.entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name);
-        for(const QFileInfo &dir : dirs)
-        {
-            if (QString::compare(dir.fileName(), themeName, Qt::CaseInsensitive) == 0 &&
-                QDir(dir.absoluteFilePath()).exists(QL1S("lxqt-panel.qss")))
-            {
-                return dir.absoluteFilePath();
-            }
-        }
+        QDir dir(QString::fromLatin1("%1/lxqt/themes/%2").arg(path, themeName));
+        if (dir.isReadable())
+            return dir.absolutePath();
     }
 
     return QString();
@@ -562,7 +555,7 @@ const LXQtTheme &LXQtTheme::currentTheme()
 {
     static LXQtTheme theme;
     QString name = Settings::globalSettings()->value(QL1S("theme")).toString();
-    if (QString::compare(theme.name(), name, Qt::CaseInsensitive) != 0)
+    if (theme.name() != name)
     {
         theme = LXQtTheme(name);
     }
@@ -585,15 +578,14 @@ QList<LXQtTheme> LXQtTheme::allThemes()
     for(const QString &path : qAsConst(paths))
     {
         QDir dir(QString::fromLatin1("%1/lxqt/themes").arg(path));
-        const QFileInfoList dirs = dir.entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name);
+        const QFileInfoList dirs = dir.entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot);
 
         for(const QFileInfo &dir : dirs)
         {
-            auto name = dir.fileName().toLower();
-            if (!processed.contains(name) &&
-                QDir(dir.absoluteFilePath()).exists(QL1S("lxqt-panel.qss")))
+            if (!processed.contains(dir.fileName()) &&
+                 QDir(dir.absoluteFilePath()).exists(QL1S("lxqt-panel.qss")))
             {
-                processed << name;
+                processed << dir.fileName();
                 ret << LXQtTheme(dir.absoluteFilePath());
             }
 
@@ -706,8 +698,7 @@ void GlobalSettings::fileChanged()
 
     QString rt = value(QL1S("theme")).toString();
     qlonglong themeUpdated = value(QL1S("__theme_updated__")).toLongLong();
-    if (QString::compare(d->mLXQtTheme, rt, Qt::CaseInsensitive) != 0 ||
-        d->mThemeUpdated != themeUpdated)
+    if ((d->mLXQtTheme != rt) || (d->mThemeUpdated != themeUpdated))
     {
         d->mLXQtTheme = rt;
         Q_EMIT lxqtThemeChanged();


### PR DESCRIPTION
This reverses https://github.com/lxqt/liblxqt/commit/ead8ceefa2a142b59e346b9df39a0070de709c73. After a discussion with @yan12125, it turned out to be redundant (especially see https://github.com/lxqt/lxqt-themes/issues/69#issuecomment-1114882618).