### PR TITLE
Add a timeout to the reboot/poweroff ... confirmation dialog

### DIFF
--- a/lxqtpowermanager.h
+++ b/lxqtpowermanager.h
@@ -62,6 +62,7 @@ public:
 private:
     LXQt::Power * m_power;
     bool m_skipWarning;
+    int m_timeoutWarning;
 
 private Q_SLOTS:
     void hibernateFailed();


### PR DESCRIPTION
Add a timeout to the confirmation dialog for
- poweroff
- shutdown
- logout
- hibernate
- suspend If the timeout expires, it is considered like the user pressed Ok.

The timeout is set on the basis of the `timeout_confirmation` settings:
- -1   -> not timeout at all
- 0    -> the confirmation dialog disappear instantly
- 1... -> the dialog closes itself after the timeout set

This patch is inspired to the current behavior in mate-desktop, where the confirmation dialogs have a timeout.
Also this patch correct a bug where the method   `MessageBox::warning` ignores `title` and `text`