### PR TITLE
Typo fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -89,7 +89,7 @@ liblxqt-0.14.0 / 2019-01-25
     - lxqtpageselectwidget: Fixed config dialog select widget cells
   * Improved cmake scripting
     - Set cmake_minimum_required to 3.1.0
-    - Removed locale compile definitons
+    - Removed locale compile definitions
   * Moved translations from lxqt-l10n back to liblxqt
     - Removed obsolete translation fuctionality
     - Added translation promo in README.md
@@ -169,7 +169,7 @@ liblxqt-0.13.0 / 2018-05-21
 ===================
 
   * Release 0.11.0: Add changelog
-  * Bump version ot 0.11.0 (#105)
+  * Bump version to 0.11.0 (#105)
   * Settings: Make use of reverse_iterator conditional
   * Application: Add <cerrno> include
   * Settings: Add "homemade" XDG_CONFIG_DIRS support
@@ -287,7 +287,7 @@ liblxqt-0.13.0 / 2018-05-21
   * Updates translations
   * Moves the about dialog to lxqt-about
   * debug: showing qDebug()/qWarning() only in "debug" build
-  * LxQtTheme: removed superfluous warning (can't occure)
+  * LxQtTheme: removed superfluous warning (can't occur)
   * debug: strip debug messages in "release" build
   * Remove AddPluginDialog as it is no longer used
   * Hungarian translation update
@@ -330,7 +330,7 @@ liblxqt-0.13.0 / 2018-05-21
   * remove not needed whitespaces
   * Adds StartOptions to the SingleApplication class
   * Adds the LxQt::SingleApplication class.
-  * CMakeLists.txt maintenaince
+  * CMakeLists.txt maintenance
   * Fixes yet another translations install dir mistake
   * Get rid of USE_QT5 in lxqt-config.cmake
   * Fixes translations install dir
@@ -373,7 +373,7 @@ liblxqt-0.13.0 / 2018-05-21
   * Fix top-to-bottom layout x-coord calculation
   * Fix broken *.ts files and update to the latest strings.
   * Replace LXDE-Qt with LXQt.
-  * Add -locations absolute option to lupdate so our *.ts files can contain informations about the source lines.
+  * Add -locations absolute option to lupdate so our *.ts files can contain information about the source lines.
   * Fix incorrect namespace in the *.ts files.
   * Add code to update the *.ts files when the UPDATE_TRANSLATIONS option is turned on.
   * Fix context names which uses C++ namespaces in all of the *.ts files.
@@ -400,10 +400,10 @@ liblxqt-0.13.0 / 2018-05-21
   * Use newer version of cmake 2.8.9
   * Detect the path of qmake correctly for Qt5.
   * Fix internal include
-  * Fix after merging from master, by removing dupplicated items
+  * Fix after merging from master, by removing duplicated items
   * Merge branch 'master' of https://github.com/lxde/liblxqt into qt5
   * Update qt5 porting
-  * Update Turkish tranlations
+  * Update Turkish translations
   * Set include dirs properly.
   * Install pkgconfig file to /usr/local/libdata/pkgconfig when FreeBSD is detected.
   * Set link directories properly
@@ -569,7 +569,7 @@ liblxqt-0.13.0 / 2018-05-21
   * Small improvement to dialog icon sizing
   * Don't reset when pressing Enter
   * reduce error messages when there is no session running in razor-power
-  * QDbusError canot be print out on Ubuntu version of qt
+  * QDbusError cannot be print out on Ubuntu version of qt
   * notification client library uses a QMessageBox failback message when it's not able to send a dbus message
   * fixed #147 razorpower: things to implement - notifications
   * default arguments for notification client lib
@@ -594,7 +594,7 @@ liblxqt-0.13.0 / 2018-05-21
   * fix for theme loading when there is no theme specified in config
   * Added localizedValue() in RazorSettings
   * Fix: wrong path for debug log
-  * Config coresponds XDG directory specification
+  * Config corresponds XDG directory specification
   * Transifex desktop: sr_BA.ts should be a local
   * strongly enhances debugging
   * Transifex desktop: local translations
@@ -618,7 +618,7 @@ liblxqt-0.13.0 / 2018-05-21
   * Env variables for plugins dirs   RAZORQT_DESKTOP_PLUGINS_DIR & RAZORQT_DESKTOP_PLUGINS_SO_DIR   RAZORQT_PANEL_PLUGINS_DIR & RAZORQT_PANEL_PLUGINS_SO_DIR
   * Create a "standardized" configuration dialog
   * Relicense razorqtlib
-  * XdgAutoStart rewriten (lgpl2+)
+  * XdgAutoStart rewritten (lgpl2+)
   * Fix gmail.ru -> gmail.com
   * Issue#147 add return value to provide a valuable feedback to user
   * menus are adopted to the new backends; old code removed; check for running razor-session to allow/disallow "logout" item
@@ -647,7 +647,7 @@ liblxqt-0.13.0 / 2018-05-21
   * New doxygen ifrastructure
   * power manager: list actions only if is user allowed to call it
   * fixed warning: The Free Software Foundation address in this file seems to be outdated
-  * devel-docs generated in CMAKE_BINARY_DIR/docs includig dummy index.html
+  * devel-docs generated in CMAKE_BINARY_DIR/docs including dummy index.html
   * missing translations in CMakeLists
   * XdgDesktopFile is implicitly shared
   * huge refactoring of the libraries build organization

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(LXQT_MINOR_VERSION 2)
 #
 # In a perfect world all components would have the same major- and minor- and
 # patch-version as liblxqt - in real life it will be fine if every component
-# has it's own patch version within a major/minor life cyle.
+# has it's own patch version within a major/minor life cycle.
 #
 set(LXQT_PATCH_VERSION 0)
 set(LXQT_VERSION ${LXQT_MAJOR_VERSION}.${LXQT_MINOR_VERSION}.${LXQT_PATCH_VERSION})
@@ -276,7 +276,7 @@ set(CFG_LXQT_TARGETS_FILE   "${LXQT_INTREE_TARGETS_FILE}")
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/lxqt-config.cmake.in"
     "${CMAKE_BINARY_DIR}/${LXQT_LIBRARY_NAME}-config.cmake"
-    INSTALL_DESTINATION "neverland"     # required, altough we don't install it
+    INSTALL_DESTINATION "neverland"     # required, although we don't install it
 )
 
 #************************************************

--- a/cmake/lxqt-config.cmake.in
+++ b/cmake/lxqt-config.cmake.in
@@ -20,7 +20,7 @@ endif (NOT APPLE)
 include(LXQtConfigVars)
 
 
-#  - Set version informations
+#  - Set version information
 set(LXQT_MAJOR_VERSION      "@LXQT_MAJOR_VERSION@")
 set(LXQT_MINOR_VERSION      "@LXQT_MINOR_VERSION@")
 set(LXQT_PATCH_VERSION      "@LXQT_PATCH_VERSION@")

--- a/lxqtapplication.cpp
+++ b/lxqtapplication.cpp
@@ -148,5 +148,5 @@ void Application::listenToUnixSignals(QList<int> const & signalList)
 
     if (SignalHandler::instance.isNull())
         SignalHandler::instance.reset(new SignalHandler{this, [this] (int signo) { Q_EMIT unixSignal(signo); }});
-    SignalHandler::instance->listenToSignals(signoList);
+    SignalHandler::instance->listenToSignals(signalList);
 }

--- a/lxqtapplication.cpp
+++ b/lxqtapplication.cpp
@@ -142,11 +142,11 @@ namespace
     QScopedPointer<SignalHandler> SignalHandler::instance;
 }
 
-void Application::listenToUnixSignals(QList<int> const & signalList)
+void Application::listenToUnixSignals(QList<int> const & signoList)
 {
     static QScopedPointer<QSocketNotifier> signal_notifier;
 
     if (SignalHandler::instance.isNull())
         SignalHandler::instance.reset(new SignalHandler{this, [this] (int signo) { Q_EMIT unixSignal(signo); }});
-    SignalHandler::instance->listenToSignals(signalList);
+    SignalHandler::instance->listenToSignals(signoList);
 }

--- a/lxqtapplication.cpp
+++ b/lxqtapplication.cpp
@@ -142,11 +142,11 @@ namespace
     QScopedPointer<SignalHandler> SignalHandler::instance;
 }
 
-void Application::listenToUnixSignals(QList<int> const & signoList)
+void Application::listenToUnixSignals(QList<int> const & signalList)
 {
     static QScopedPointer<QSocketNotifier> signal_notifier;
 
     if (SignalHandler::instance.isNull())
         SignalHandler::instance.reset(new SignalHandler{this, [this] (int signo) { Q_EMIT unixSignal(signo); }});
-    SignalHandler::instance->listenToSignals(signoList);
+    SignalHandler::instance->listenToSignals(signalList);
 }

--- a/lxqtapplication.cpp
+++ b/lxqtapplication.cpp
@@ -142,7 +142,7 @@ namespace
     QScopedPointer<SignalHandler> SignalHandler::instance;
 }
 
-void Application::listenToUnixSignals(QList<int> const & signoList)
+void Application::listenToUnixSignals(QList<int> const & signalList)
 {
     static QScopedPointer<QSocketNotifier> signal_notifier;
 

--- a/lxqtapplication.h
+++ b/lxqtapplication.h
@@ -60,10 +60,10 @@ public:
      */
     Application(int &argc, char **argv, bool handleQuitSignals);
     ~Application() override {}
-    /*! Install UNIX signal handler for signals defined in \param signalList
+    /*! Install UNIX signal handler for signals defined in \param signoList
      * Upon receiving of any of this signals the \sa unixSignal signal is emitted
      */
-    void listenToUnixSignals(QList<int> const & signalList);
+    void listenToUnixSignals(QList<int> const & signoList);
 
 private Q_SLOTS:
     void updateTheme();

--- a/lxqtapplication.h
+++ b/lxqtapplication.h
@@ -56,14 +56,14 @@ public:
     /*! Construct a LXQt application object.
      * \param argc standard argc as in QApplication
      * \param argv standard argv as in QApplication
-     * \param handleQuitSignals flag if signals SIGINT, SIGTERM, SIGHUP should be handled internaly (\sa quit() application)
+     * \param handleQuitSignals flag if signals SIGINT, SIGTERM, SIGHUP should be handled internally (\sa quit() application)
      */
     Application(int &argc, char **argv, bool handleQuitSignals);
     ~Application() override {}
     /*! Install UNIX signal handler for signals defined in \param signalList
      * Upon receiving of any of this signals the \sa unixSignal signal is emitted
      */
-    void listenToUnixSignals(QList<int> const & signolList);
+    void listenToUnixSignals(QList<int> const & signalList);
 
 private Q_SLOTS:
     void updateTheme();

--- a/lxqtapplication.h
+++ b/lxqtapplication.h
@@ -60,10 +60,10 @@ public:
      */
     Application(int &argc, char **argv, bool handleQuitSignals);
     ~Application() override {}
-    /*! Install UNIX signal handler for signals defined in \param signoList
+    /*! Install UNIX signal handler for signals defined in \param signalList
      * Upon receiving of any of this signals the \sa unixSignal signal is emitted
      */
-    void listenToUnixSignals(QList<int> const & signoList);
+    void listenToUnixSignals(QList<int> const & signalList);
 
 private Q_SLOTS:
     void updateTheme();

--- a/lxqtnotification.cpp
+++ b/lxqtnotification.cpp
@@ -127,7 +127,7 @@ void Notification::notify(const QString& summary, const QString& body, const QSt
     notification.update();
 }
 
-bool NotificationPrivate::sIsServerInfoQuried = 0;
+bool NotificationPrivate::sIsServerInfoQueried = 0;
 Notification::ServerInfo NotificationPrivate::sServerInfo;
 
 NotificationPrivate::NotificationPrivate(const QString& summary, Notification* parent) :
@@ -180,7 +180,7 @@ void NotificationPrivate::setActions(QStringList actions, int defaultAction)
 
 const Notification::ServerInfo NotificationPrivate::serverInfo()
 {
-    if (!sIsServerInfoQuried) {
+    if (!sIsServerInfoQueried) {
         queryServerInfo (/*async=*/false);
     }
 
@@ -207,7 +207,7 @@ void NotificationPrivate::queryServerInfo(bool async)
                 sServerInfo.version.clear();
                 sServerInfo.specVersion.clear();
             }
-            sIsServerInfoQuried = true;
+            sIsServerInfoQueried = true;
             Q_EMIT q->serverInfoReady();
             sender()->deleteLater();
         });

--- a/lxqtnotification.h
+++ b/lxqtnotification.h
@@ -150,7 +150,7 @@ public:
     const ServerInfo serverInfo();
 
     /*!
-     * \brief Performs an asyncronous query of the notifications server information.
+     * \brief Performs an asynchronous query of the notifications server information.
      *        Use serverInfoReady signal to get notified (no pun intended) when the
      *        info will be received.
      * \sa serverInfo()

--- a/lxqtnotification_p.h
+++ b/lxqtnotification_p.h
@@ -61,7 +61,7 @@ private:
     int mTimeout;
 
     static Notification::ServerInfo sServerInfo;
-    static bool sIsServerInfoQuried;
+    static bool sIsServerInfoQueried;
 
     Notification* const q_ptr;
     Q_DECLARE_PUBLIC(Notification)

--- a/lxqtsettings.cpp
+++ b/lxqtsettings.cpp
@@ -236,7 +236,7 @@ void Settings::addWatchedFile(QString const & path)
     // Luckily, I found a workaround: If the file path no longer exists
     // in the watcher's files(), this file is deleted.
     if(!d_ptr->mWatcher.files().contains(path))
-        // in some situations adding fails because of non-existing file (e.g. editting file in external program)
+        // in some situations adding fails because of non-existing file (e.g. editing file in external program)
         if (!d_ptr->mWatcher.addPath(path) && 0 == d_ptr->mAddWatchTimer)
             d_ptr->mAddWatchTimer = startTimer(100);
 


### PR DESCRIPTION
Typo fixes to comments/text and identifiers. Half of the changes are to CHANGELOG.

Affected files:
- CHANGELOG
- CMakeLists.txt
- lxqtapplication.h
- lxqtnotification.cpp
- lxqtnotification.h
- lxqtnotification_p.h
- lxqtsettings.cpp
- cmake/lxqt-config.cmake.in