### PR TITLE
Replaced `QLatin1String` with `QLatin1StringView`

### DIFF
--- a/configdialog/lxqtconfigdialog.cpp
+++ b/configdialog/lxqtconfigdialog.cpp
@@ -133,7 +133,7 @@ void ConfigDialog::addPage(QWidget* page, const QString& name, const QStringList
         page->layout()->setContentsMargins(QMargins());
     }
 
-    QStringList icons = QStringList(iconNames) << QL1S("application-x-executable");
+    QStringList icons = QStringList(iconNames) << QL1SV("application-x-executable");
     new QListWidgetItem(XdgIcon::fromTheme(icons), name, d->ui->moduleList);
     d->mIcons.append(icons);
     d->ui->stackedWidget->addWidget(page);

--- a/configdialog/lxqtconfigdialog.h
+++ b/configdialog/lxqtconfigdialog.h
@@ -63,7 +63,7 @@ public:
     /*!
      * Add a page to the configure dialog
      */
-    void addPage(QWidget* page, const QString& name, const QString& iconName = QL1S("application-x-executable"));
+    void addPage(QWidget* page, const QString& name, const QString& iconName = QL1SV("application-x-executable"));
 
     /*!
      * Add a page to the configure dialog, attempting several alternative icons to find one in the theme

--- a/configdialog/lxqtconfigdialog.h
+++ b/configdialog/lxqtconfigdialog.h
@@ -63,7 +63,7 @@ public:
     /*!
      * Add a page to the configure dialog
      */
-    void addPage(QWidget* page, const QString& name, const QString& iconName = QLatin1String("application-x-executable"));
+    void addPage(QWidget* page, const QString& name, const QString& iconName = QL1S("application-x-executable"));
 
     /*!
      * Add a page to the configure dialog, attempting several alternative icons to find one in the theme

--- a/configdialog/lxqtconfigdialogcmdlineoptions.cpp
+++ b/configdialog/lxqtconfigdialogcmdlineoptions.cpp
@@ -44,13 +44,13 @@ bool ConfigDialogCmdLineOptions::setCommandLine(QCommandLineParser *parser)
     if (!parser)
         return false;
 
-    return parser->addOption(QCommandLineOption{QStringList{QL1S("s"), QL1S("show-page")}, QCoreApplication::tr("Choose the page to be shown."), QL1S("name")});
+    return parser->addOption(QCommandLineOption{QStringList{QL1SV("s"), QL1SV("show-page")}, QCoreApplication::tr("Choose the page to be shown."), QL1SV("name")});
 }
 
 void ConfigDialogCmdLineOptions::process(QCommandLineParser &parser)
 {
-    if (parser.isSet(QL1S("show-page"))) {
-        d->mPage = parser.value(QL1S("show-page"));
+    if (parser.isSet(QL1SV("show-page"))) {
+        d->mPage = parser.value(QL1SV("show-page"));
     }
 }
 

--- a/lxqtapplication.cpp
+++ b/lxqtapplication.cpp
@@ -55,7 +55,7 @@ using namespace LXQt;
 Application::Application(int &argc, char** argv)
     : QApplication(argc, argv)
 {
-    setWindowIcon(QIcon(QFile::decodeName(LXQT_GRAPHICS_DIR) + QL1S("/lxqt_logo.png")));
+    setWindowIcon(QIcon(QFile::decodeName(LXQT_GRAPHICS_DIR) + QL1SV("/lxqt_logo.png")));
     connect(Settings::globalSettings(), &GlobalSettings::lxqtThemeChanged, this, &Application::updateTheme);
     updateTheme();
 }

--- a/lxqtautostartentry.cpp
+++ b/lxqtautostartentry.cpp
@@ -102,16 +102,16 @@ void AutostartEntry::setEnabled(bool enable)
 {
     XdgDesktopFile f = file();
     if (enable)
-        f.removeEntry(QL1S("Hidden"));
+        f.removeEntry(QL1SV("Hidden"));
     else
-        f.setValue(QL1S("Hidden"), true);
+        f.setValue(QL1SV("Hidden"), true);
 
     setFile(f);
 }
 
 bool AutostartEntry::isEnabled() const
 {
-    return !isEmpty() && !file().value(QL1S("Hidden"), false).toBool();
+    return !isEmpty() && !file().value(QL1SV("Hidden"), false).toBool();
 }
 
 bool AutostartEntry::commit()

--- a/lxqtbacklight/linux_backend/linuxbackend.cpp
+++ b/lxqtbacklight/linux_backend/linuxbackend.cpp
@@ -48,9 +48,9 @@ LinuxBackend::LinuxBackend(QObject *parent):VirtualBackEnd(parent)
     if( isBacklightAvailable() ) {
         char *driver = lxqt_backlight_backend_get_driver();
         fileSystemWatcher = new QFileSystemWatcher(this);
-        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/actual_brightness").arg(QL1S(driver)));
-        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/brightness").arg(QL1S(driver)));
-        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/bl_power").arg(QL1S(driver)));
+        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/actual_brightness").arg(QL1SV(driver)));
+        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/brightness").arg(QL1SV(driver)));
+        fileSystemWatcher->addPath(QString::fromLatin1("/sys/class/backlight/%1/bl_power").arg(QL1SV(driver)));
         free(driver);
         actualBacklight = lxqt_backlight_backend_get();
         connect(fileSystemWatcher, &QFileSystemWatcher::fileChanged,

--- a/lxqtglobals.h
+++ b/lxqtglobals.h
@@ -40,6 +40,10 @@
 #define QL1S(x) QLatin1StringView(x)
 #endif
 
+#ifndef QL1SV
+#define QL1SV(x) QLatin1StringView(x)
+#endif
+
 #ifndef QL1C
 #define QL1C(x) QLatin1Char(x)
 #endif

--- a/lxqtglobals.h
+++ b/lxqtglobals.h
@@ -37,7 +37,7 @@
 #endif
 
 #ifndef QL1S
-#define QL1S(x) QLatin1String(x)
+#define QL1S(x) QLatin1StringView(x)
 #endif
 
 #ifndef QL1C

--- a/lxqtnotification.cpp
+++ b/lxqtnotification.cpp
@@ -92,7 +92,7 @@ void Notification::setHint(const QString& hintName, const QVariant& value)
 void Notification::setUrgencyHint(Urgency urgency)
 {
     Q_D(Notification);
-    d->mHints.insert(QL1S("urgency"), qvariant_cast<uchar>(urgency));
+    d->mHints.insert(QL1SV("urgency"), qvariant_cast<uchar>(urgency));
 }
 
 void Notification::clearHints()
@@ -136,8 +136,8 @@ NotificationPrivate::NotificationPrivate(const QString& summary, Notification* p
     mTimeout(-1),
     q_ptr(parent)
 {
-    mInterface = new OrgFreedesktopNotificationsInterface(QL1S("org.freedesktop.Notifications"),
-                                                          QL1S("/org/freedesktop/Notifications"),
+    mInterface = new OrgFreedesktopNotificationsInterface(QL1SV("org.freedesktop.Notifications"),
+                                                          QL1SV("/org/freedesktop/Notifications"),
                                                           QDBusConnection::sessionBus(), this);
     connect(mInterface, &OrgFreedesktopNotificationsInterface::NotificationClosed,
         this, &NotificationPrivate::notificationClosed);
@@ -157,8 +157,8 @@ void NotificationPrivate::update()
     }
     else
     {
-        if (mHints.contains(QL1S("urgency")) && mHints.value(QL1S("urgency")).toInt() != Notification::UrgencyLow)
-            QMessageBox::information(nullptr, tr("Notifications Fallback"), mSummary + QL1S(" \n\n ") + mBody);
+        if (mHints.contains(QL1SV("urgency")) && mHints.value(QL1SV("urgency")).toInt() != Notification::UrgencyLow)
+            QMessageBox::information(nullptr, tr("Notifications Fallback"), mSummary + QL1SV(" \n\n ") + mBody);
     }
 }
 
@@ -171,7 +171,7 @@ void NotificationPrivate::setActions(QStringList actions, int defaultAction)
     for (int ix = 0; ix < N; ix++)
     {
         if (ix == defaultAction)
-            mActions.append(QL1S("default"));
+            mActions.append(QL1SV("default"));
         else
             mActions.append(QString::number(ix));
         mActions.append(actions[ix]);
@@ -228,7 +228,7 @@ void NotificationPrivate::handleAction(uint id, const QString& key)
     qDebug() << "action invoked:" << key;
     bool ok = true;
     int keyId;
-    if (key == QL1S("default"))
+    if (key == QL1SV("default"))
         keyId = mDefaultAction;
     else
         keyId = key.toInt(&ok);

--- a/lxqtplugininfo.cpp
+++ b/lxqtplugininfo.cpp
@@ -75,7 +75,7 @@ QLibrary* PluginInfo::loadLibrary(const QString& libDir) const
 {
     const QFileInfo fi = QFileInfo(fileName());
     const QString path = fi.canonicalPath();
-    const QString baseName = value(QL1S("X-LXQt-Library"), fi.completeBaseName()).toString();
+    const QString baseName = value(QL1SV("X-LXQt-Library"), fi.completeBaseName()).toString();
 
     const QString soPath = QDir(libDir).filePath(QString::fromLatin1("lib%2.so").arg(baseName));
     QLibrary* library = new QLibrary(soPath);
@@ -157,7 +157,7 @@ LXQT_API QDebug operator<<(QDebug dbg, const PluginInfoList& list)
     dbg.nospace() << QL1C('(');
     for (int i=0; i<list.size(); ++i)
     {
-        if (i) dbg.nospace() << QL1S(", ");
+        if (i) dbg.nospace() << QL1SV(", ");
         dbg << list.at(i);
     }
     dbg << QL1C(')');

--- a/lxqtplugininfo.h
+++ b/lxqtplugininfo.h
@@ -94,10 +94,10 @@ public:
 
       If the same filename is located under multiple directories only the first file should be used.
     */
-    static QList<PluginInfo> search(const QStringList& desktopFilesDirs, const QString& serviceType, const QString& nameFilter = QLatin1String("*"));
+    static QList<PluginInfo> search(const QStringList& desktopFilesDirs, const QString& serviceType, const QString& nameFilter = QL1S("*"));
 
     /// This function is provided for convenience. It's equivalent to new calling search(QString(desktopFilesDir), serviceType, nameFilter)
-    static QList<PluginInfo> search(const QString& desktopFilesDir, const QString& serviceType, const QString& nameFilter = QLatin1String("*"));
+    static QList<PluginInfo> search(const QString& desktopFilesDir, const QString& serviceType, const QString& nameFilter = QL1S("*"));
 
 private:
     QString mId;

--- a/lxqtplugininfo.h
+++ b/lxqtplugininfo.h
@@ -77,7 +77,7 @@ public:
     QString id() const { return mId; }
 
     //! This function is provided for convenience. It's equivalent to calling value("ServiceTypes").toString().
-    QString serviceType() const  { return value(QL1S("ServiceTypes")).toString(); }
+    QString serviceType() const  { return value(QL1SV("ServiceTypes")).toString(); }
 
     //! Reimplemented from XdgDesktopFile.
     virtual bool isValid() const;
@@ -94,10 +94,10 @@ public:
 
       If the same filename is located under multiple directories only the first file should be used.
     */
-    static QList<PluginInfo> search(const QStringList& desktopFilesDirs, const QString& serviceType, const QString& nameFilter = QL1S("*"));
+    static QList<PluginInfo> search(const QStringList& desktopFilesDirs, const QString& serviceType, const QString& nameFilter = QL1SV("*"));
 
     /// This function is provided for convenience. It's equivalent to new calling search(QString(desktopFilesDir), serviceType, nameFilter)
-    static QList<PluginInfo> search(const QString& desktopFilesDir, const QString& serviceType, const QString& nameFilter = QL1S("*"));
+    static QList<PluginInfo> search(const QString& desktopFilesDir, const QString& serviceType, const QString& nameFilter = QL1SV("*"));
 
 private:
     QString mId;

--- a/lxqtpower/lxqtpowerproviders.cpp
+++ b/lxqtpower/lxqtpowerproviders.cpp
@@ -85,8 +85,8 @@ static bool dbusCall(const QString &service,
         {
             Notification::notify(
                                     QObject::tr("Power Manager Error"),
-                                    QObject::tr("QDBusInterface is invalid") + QL1S("\n\n") + service + QL1C(' ') + path + QL1C(' ') + interface + QL1C(' ') + method,
-                                    QL1S("lxqt-logo.png"));
+                                    QObject::tr("QDBusInterface is invalid") + QL1SV("\n\n") + service + QL1C(' ') + path + QL1C(' ') + interface + QL1C(' ') + method,
+                                    QL1SV("lxqt-logo.png"));
         }
         return false;
     }
@@ -100,8 +100,8 @@ static bool dbusCall(const QString &service,
         {
             Notification::notify(
                                     QObject::tr("Power Manager Error (D-BUS call)"),
-                                    msg.errorName() + QL1S("\n\n") + msg.errorMessage(),
-                                    QL1S("lxqt-logo.png"));
+                                    msg.errorName() + QL1SV("\n\n") + msg.errorMessage(),
+                                    QL1SV("lxqt-logo.png"));
         }
     }
 
@@ -135,8 +135,8 @@ static bool dbusCallSystemd(const QString &service,
         {
             Notification::notify(
                                     QObject::tr("Power Manager Error"),
-                                    QObject::tr("QDBusInterface is invalid") + QL1S("\n\n") + service + QL1C(' ') + path + QL1C(' ')+ interface + QL1C(' ') + method,
-                                    QL1S("lxqt-logo.png"));
+                                    QObject::tr("QDBusInterface is invalid") + QL1SV("\n\n") + service + QL1C(' ') + path + QL1C(' ')+ interface + QL1C(' ') + method,
+                                    QL1SV("lxqt-logo.png"));
         }
         return false;
     }
@@ -150,8 +150,8 @@ static bool dbusCallSystemd(const QString &service,
         {
             Notification::notify(
                                     QObject::tr("Power Manager Error (D-BUS call)"),
-                                    msg.errorName() + QL1S("\n\n") + msg.errorMessage(),
-                                    QL1S("lxqt-logo.png"));
+                                    msg.errorName() + QL1SV("\n\n") + msg.errorMessage(),
+                                    QL1SV("lxqt-logo.png"));
         }
     }
 
@@ -161,7 +161,7 @@ static bool dbusCallSystemd(const QString &service,
 
     QString response = msg.arguments().constFirst().toString();
     qDebug() << "systemd:" << method << "=" << response;
-    return response == QL1S("yes") || response == QL1S("challenge");
+    return response == QL1SV("yes") || response == QL1SV("challenge");
 }
 
 
@@ -187,7 +187,7 @@ bool dbusGetProperty(const QString &service,
         return false;
     }
 
-    QDBusMessage msg = dbus.call(QL1S("Get"), dbus.interface(), property);
+    QDBusMessage msg = dbus.call(QL1SV("Get"), dbus.interface(), property);
 
     if (!msg.errorName().isEmpty())
     {
@@ -237,13 +237,13 @@ bool UPowerProvider::canAction(Power::Action action) const
     switch (action)
     {
     case Power::PowerHibernate:
-        property = QL1S("CanHibernate");
-        command  = QL1S("HibernateAllowed");
+        property = QL1SV("CanHibernate");
+        command  = QL1SV("HibernateAllowed");
         break;
 
     case Power::PowerSuspend:
-        property = QL1S("CanSuspend");
-        command  = QL1S("SuspendAllowed");
+        property = QL1SV("CanSuspend");
+        command  = QL1SV("SuspendAllowed");
         break;
 
     default:
@@ -251,17 +251,17 @@ bool UPowerProvider::canAction(Power::Action action) const
     }
 
     return  dbusGetProperty(  // Whether the system is able to hibernate.
-                QL1S(UPOWER_SERVICE),
-                QL1S(UPOWER_PATH),
-                QL1S(PROPERTIES_INTERFACE),
+                QL1SV(UPOWER_SERVICE),
+                QL1SV(UPOWER_PATH),
+                QL1SV(PROPERTIES_INTERFACE),
                 QDBusConnection::systemBus(),
                 property
             )
             &&
             dbusCall( // Check if the caller has (or can get) the PolicyKit privilege to call command.
-                QL1S(UPOWER_SERVICE),
-                QL1S(UPOWER_PATH),
-                QL1S(UPOWER_INTERFACE),
+                QL1SV(UPOWER_SERVICE),
+                QL1SV(UPOWER_PATH),
+                QL1SV(UPOWER_INTERFACE),
                 QDBusConnection::systemBus(),
                 command,
                 // canAction should be always silent because it can freeze
@@ -279,11 +279,11 @@ bool UPowerProvider::doAction(Power::Action action)
     switch (action)
     {
     case Power::PowerHibernate:
-        command = QL1S("Hibernate");
+        command = QL1SV("Hibernate");
         break;
 
     case Power::PowerSuspend:
-        command = QL1S("Suspend");
+        command = QL1SV("Suspend");
         break;
 
     default:
@@ -291,9 +291,9 @@ bool UPowerProvider::doAction(Power::Action action)
     }
 
 
-    return dbusCall(QL1S(UPOWER_SERVICE),
-             QL1S(UPOWER_PATH),
-             QL1S(UPOWER_INTERFACE),
+    return dbusCall(QL1SV(UPOWER_SERVICE),
+             QL1SV(UPOWER_PATH),
+             QL1SV(UPOWER_INTERFACE),
              QDBusConnection::systemBus(),
              command );
 }
@@ -318,28 +318,28 @@ bool ConsoleKitProvider::canAction(Power::Action action) const
     switch (action)
     {
     case Power::PowerReboot:
-        command = QL1S("CanReboot");
+        command = QL1SV("CanReboot");
         break;
 
     case Power::PowerShutdown:
-        command = QL1S("CanPowerOff");
+        command = QL1SV("CanPowerOff");
         break;
 
     case Power::PowerHibernate:
-        command  = QL1S("CanHibernate");
+        command  = QL1SV("CanHibernate");
         break;
 
     case Power::PowerSuspend:
-        command  = QL1S("CanSuspend");
+        command  = QL1SV("CanSuspend");
         break;
 
     default:
         return false;
     }
 
-    return dbusCallSystemd(QL1S(CONSOLEKIT_SERVICE),
-                    QL1S(CONSOLEKIT_PATH),
-                    QL1S(CONSOLEKIT_INTERFACE),
+    return dbusCallSystemd(QL1SV(CONSOLEKIT_SERVICE),
+                    QL1SV(CONSOLEKIT_PATH),
+                    QL1SV(CONSOLEKIT_INTERFACE),
                     QDBusConnection::systemBus(),
                     command,
                     false,
@@ -357,28 +357,28 @@ bool ConsoleKitProvider::doAction(Power::Action action)
     switch (action)
     {
     case Power::PowerReboot:
-        command = QL1S("Reboot");
+        command = QL1SV("Reboot");
         break;
 
     case Power::PowerShutdown:
-        command = QL1S("PowerOff");
+        command = QL1SV("PowerOff");
         break;
 
     case Power::PowerHibernate:
-        command = QL1S("Hibernate");
+        command = QL1SV("Hibernate");
         break;
 
     case Power::PowerSuspend:
-        command = QL1S("Suspend");
+        command = QL1SV("Suspend");
         break;
 
     default:
         return false;
     }
 
-    return dbusCallSystemd(QL1S(CONSOLEKIT_SERVICE),
-                QL1S(CONSOLEKIT_PATH),
-                QL1S(CONSOLEKIT_INTERFACE),
+    return dbusCallSystemd(QL1SV(CONSOLEKIT_SERVICE),
+                QL1SV(CONSOLEKIT_PATH),
+                QL1SV(CONSOLEKIT_INTERFACE),
                 QDBusConnection::systemBus(),
                 command,
                 true
@@ -407,28 +407,28 @@ bool SystemdProvider::canAction(Power::Action action) const
     switch (action)
     {
     case Power::PowerReboot:
-        command = QL1S("CanReboot");
+        command = QL1SV("CanReboot");
         break;
 
     case Power::PowerShutdown:
-        command = QL1S("CanPowerOff");
+        command = QL1SV("CanPowerOff");
         break;
 
     case Power::PowerSuspend:
-        command = QL1S("CanSuspend");
+        command = QL1SV("CanSuspend");
         break;
 
     case Power::PowerHibernate:
-        command = QL1S("CanHibernate");
+        command = QL1SV("CanHibernate");
         break;
 
     default:
         return false;
     }
 
-    return dbusCallSystemd(QL1S(SYSTEMD_SERVICE),
-                    QL1S(SYSTEMD_PATH),
-                    QL1S(SYSTEMD_INTERFACE),
+    return dbusCallSystemd(QL1SV(SYSTEMD_SERVICE),
+                    QL1SV(SYSTEMD_PATH),
+                    QL1SV(SYSTEMD_INTERFACE),
                     QDBusConnection::systemBus(),
                     command,
                     false,
@@ -447,28 +447,28 @@ bool SystemdProvider::doAction(Power::Action action)
     switch (action)
     {
     case Power::PowerReboot:
-        command = QL1S("Reboot");
+        command = QL1SV("Reboot");
         break;
 
     case Power::PowerShutdown:
-        command = QL1S("PowerOff");
+        command = QL1SV("PowerOff");
         break;
 
     case Power::PowerSuspend:
-        command = QL1S("Suspend");
+        command = QL1SV("Suspend");
         break;
 
     case Power::PowerHibernate:
-        command = QL1S("Hibernate");
+        command = QL1SV("Hibernate");
         break;
 
     default:
         return false;
     }
 
-    return dbusCallSystemd(QL1S(SYSTEMD_SERVICE),
-             QL1S(SYSTEMD_PATH),
-             QL1S(SYSTEMD_INTERFACE),
+    return dbusCallSystemd(QL1SV(SYSTEMD_SERVICE),
+             QL1SV(SYSTEMD_PATH),
+             QL1SV(SYSTEMD_INTERFACE),
              QDBusConnection::systemBus(),
              command,
              true
@@ -494,20 +494,20 @@ bool LXQtProvider::canAction(Power::Action action) const
     switch (action)
     {
         case Power::PowerLogout:
-            command = QL1S("canLogout");
+            command = QL1SV("canLogout");
             break;
         case Power::PowerReboot:
-            command = QL1S("canReboot");
+            command = QL1SV("canReboot");
             break;
         case Power::PowerShutdown:
-            command = QL1S("canPowerOff");
+            command = QL1SV("canPowerOff");
             break;
         default:
             return false;
     }
 
     // there can be case when lxqtsession-session does not run
-    return dbusCall(QL1S(LXQT_SERVICE), QL1S(LXQT_PATH), QL1S(LXQT_INTERFACE),
+    return dbusCall(QL1SV(LXQT_SERVICE), QL1SV(LXQT_PATH), QL1SV(LXQT_INTERFACE),
             QDBusConnection::sessionBus(), command,
             PowerProvider::DontCheckDBUS);
 }
@@ -519,21 +519,21 @@ bool LXQtProvider::doAction(Power::Action action)
     switch (action)
     {
         case Power::PowerLogout:
-            command = QL1S("logout");
+            command = QL1SV("logout");
             break;
         case Power::PowerReboot:
-            command = QL1S("reboot");
+            command = QL1SV("reboot");
             break;
         case Power::PowerShutdown:
-            command = QL1S("powerOff");
+            command = QL1SV("powerOff");
             break;
         default:
             return false;
     }
 
-    return dbusCall(QL1S(LXQT_SERVICE),
-             QL1S(LXQT_PATH),
-             QL1S(LXQT_INTERFACE),
+    return dbusCall(QL1SV(LXQT_SERVICE),
+             QL1SV(LXQT_PATH),
+             QL1SV(LXQT_INTERFACE),
              QDBusConnection::sessionBus(),
              command
             );
@@ -611,7 +611,7 @@ bool HalProvider::doAction(Power::Action action)
  ************************************************/
 CustomProvider::CustomProvider(QObject *parent):
     PowerProvider(parent),
-    mSettings(QL1S("power"))
+    mSettings(QL1SV("power"))
 {
 }
 
@@ -622,25 +622,25 @@ bool CustomProvider::canAction(Power::Action action) const
     switch (action)
     {
     case Power::PowerShutdown:
-        return mSettings.contains(QL1S("shutdownCommand"));
+        return mSettings.contains(QL1SV("shutdownCommand"));
 
     case Power::PowerReboot:
-        return mSettings.contains(QL1S("rebootCommand"));
+        return mSettings.contains(QL1SV("rebootCommand"));
 
     case Power::PowerHibernate:
-        return mSettings.contains(QL1S("hibernateCommand"));
+        return mSettings.contains(QL1SV("hibernateCommand"));
 
     case Power::PowerSuspend:
-        return mSettings.contains(QL1S("suspendCommand"));
+        return mSettings.contains(QL1SV("suspendCommand"));
 
     case Power::PowerLogout:
-        return mSettings.contains(QL1S("logoutCommand"));
+        return mSettings.contains(QL1SV("logoutCommand"));
 
     case Power::PowerMonitorOff:
-        return mSettings.contains(QL1S("monitorOffCommand"));
+        return mSettings.contains(QL1SV("monitorOffCommand"));
 
     case Power::PowerShowLeaveDialog:
-        return mSettings.contains(QL1S("showLeaveDialogCommand"));
+        return mSettings.contains(QL1SV("showLeaveDialogCommand"));
 
     default:
         return false;
@@ -654,31 +654,31 @@ bool CustomProvider::doAction(Power::Action action)
     switch(action)
     {
     case Power::PowerShutdown:
-        command = mSettings.value(QL1S("shutdownCommand")).toString();
+        command = mSettings.value(QL1SV("shutdownCommand")).toString();
         break;
 
     case Power::PowerReboot:
-        command = mSettings.value(QL1S("rebootCommand")).toString();
+        command = mSettings.value(QL1SV("rebootCommand")).toString();
         break;
 
     case Power::PowerHibernate:
-        command = mSettings.value(QL1S("hibernateCommand")).toString();
+        command = mSettings.value(QL1SV("hibernateCommand")).toString();
         break;
 
     case Power::PowerSuspend:
-        command = mSettings.value(QL1S("suspendCommand")).toString();
+        command = mSettings.value(QL1SV("suspendCommand")).toString();
         break;
 
     case Power::PowerLogout:
-        command = mSettings.value(QL1S("logoutCommand")).toString();
+        command = mSettings.value(QL1SV("logoutCommand")).toString();
         break;
 
     case Power::PowerMonitorOff:
-        command = mSettings.value(QL1S("monitorOffCommand")).toString();
+        command = mSettings.value(QL1SV("monitorOffCommand")).toString();
         break;
 
     case Power::PowerShowLeaveDialog:
-        command = mSettings.value(QL1S("showLeaveDialogCommand")).toString();
+        command = mSettings.value(QL1SV("showLeaveDialogCommand")).toString();
         break;
 
     default:

--- a/lxqtpowermanager.cpp
+++ b/lxqtpowermanager.cpp
@@ -88,8 +88,8 @@ PowerManager::PowerManager(QObject * parent, bool skipWarning)
 //            this, SLOT(monitoring(const QString&)));
 
     QString sessionConfig(QFile::decodeName(qgetenv("LXQT_SESSION_CONFIG")));
-    Settings settings(sessionConfig.isEmpty() ? QL1S("session") : sessionConfig);
-    m_skipWarning = settings.value(QL1S("leave_confirmation")).toBool() ? false : true;
+    Settings settings(sessionConfig.isEmpty() ? QL1SV("session") : sessionConfig);
+    m_skipWarning = settings.value(QL1SV("leave_confirmation")).toBool() ? false : true;
 }
 
 PowerManager::~PowerManager()
@@ -105,35 +105,35 @@ QList<QAction*> PowerManager::availableActions()
     // TODO/FIXME: icons
     if (m_power->canHibernate())
     {
-        act = new QAction(XdgIcon::fromTheme(QL1S("system-suspend-hibernate")), tr("Hibernate"), this);
+        act = new QAction(XdgIcon::fromTheme(QL1SV("system-suspend-hibernate")), tr("Hibernate"), this);
         connect(act, &QAction::triggered, this, &PowerManager::hibernate);
         ret.append(act);
     }
 
     if (m_power->canSuspend())
     {
-        act = new QAction(XdgIcon::fromTheme(QL1S("system-suspend")), tr("Suspend"), this);
+        act = new QAction(XdgIcon::fromTheme(QL1SV("system-suspend")), tr("Suspend"), this);
         connect(act, &QAction::triggered, this, &PowerManager::suspend);
         ret.append(act);
     }
 
     if (m_power->canReboot())
     {
-        act = new QAction(XdgIcon::fromTheme(QL1S("system-reboot")), tr("Reboot"), this);
+        act = new QAction(XdgIcon::fromTheme(QL1SV("system-reboot")), tr("Reboot"), this);
         connect(act, &QAction::triggered, this, &PowerManager::reboot);
         ret.append(act);
     }
 
     if (m_power->canShutdown())
     {
-        act = new QAction(XdgIcon::fromTheme(QL1S("system-shutdown")), tr("Shutdown"), this);
+        act = new QAction(XdgIcon::fromTheme(QL1SV("system-shutdown")), tr("Shutdown"), this);
         connect(act, &QAction::triggered, this, &PowerManager::shutdown);
         ret.append(act);
     }
 
     if (m_power->canLogout())
     {
-        act = new QAction(XdgIcon::fromTheme(QL1S("system-log-out")), tr("Logout"), this);
+        act = new QAction(XdgIcon::fromTheme(QL1SV("system-log-out")), tr("Logout"), this);
         connect(act, &QAction::triggered, this, &PowerManager::logout);
         ret.append(act);
     }

--- a/lxqtscreensaver.cpp
+++ b/lxqtscreensaver.cpp
@@ -140,10 +140,10 @@ class ScreenSaverPrivate
 
 public:
     ScreenSaverPrivate(ScreenSaver *q) : q_ptr(q) {
-        QSettings settings(QSettings::UserScope, QLatin1String("lxqt"), QLatin1String("lxqt"));
+        QSettings settings(QSettings::UserScope, QStringLiteral("lxqt"), QStringLiteral("lxqt"));
 
-        settings.beginGroup(QLatin1String("Screensaver"));
-        lock_command = settings.value(QLatin1String("lock_command"), QLatin1String("xdg-screensaver lock")).toString();
+        settings.beginGroup(QL1S("Screensaver"));
+        lock_command = settings.value(QL1S("lock_command"), QL1S("xdg-screensaver lock")).toString();
         settings.endGroup();
     }
 
@@ -165,7 +165,7 @@ void ScreenSaverPrivate::reportLockProcessError()
     QString message;
     // contains() instead of startsWith() as the command might be "env FOO=bar xdg-screensaver lock"
     // (e.g., overwrite $XDG_CURRENT_DESKTOP for some different behaviors)
-    if (lock_command.contains(QLatin1String("xdg-screensaver"))) {
+    if (lock_command.contains(QL1S("xdg-screensaver"))) {
         message = tr("Failed to run  \"%1\". "
                      "Ensure you have a locker/screensaver compatible with xdg-screensaver installed and running."
                     );

--- a/lxqtscreensaver.cpp
+++ b/lxqtscreensaver.cpp
@@ -142,8 +142,8 @@ public:
     ScreenSaverPrivate(ScreenSaver *q) : q_ptr(q) {
         QSettings settings(QSettings::UserScope, QStringLiteral("lxqt"), QStringLiteral("lxqt"));
 
-        settings.beginGroup(QL1S("Screensaver"));
-        lock_command = settings.value(QL1S("lock_command"), QL1S("xdg-screensaver lock")).toString();
+        settings.beginGroup(QL1SV("Screensaver"));
+        lock_command = settings.value(QL1SV("lock_command"), QL1SV("xdg-screensaver lock")).toString();
         settings.endGroup();
     }
 
@@ -165,7 +165,7 @@ void ScreenSaverPrivate::reportLockProcessError()
     QString message;
     // contains() instead of startsWith() as the command might be "env FOO=bar xdg-screensaver lock"
     // (e.g., overwrite $XDG_CURRENT_DESKTOP for some different behaviors)
-    if (lock_command.contains(QL1S("xdg-screensaver"))) {
+    if (lock_command.contains(QL1SV("xdg-screensaver"))) {
         message = tr("Failed to run  \"%1\". "
                      "Ensure you have a locker/screensaver compatible with xdg-screensaver installed and running."
                     );
@@ -256,7 +256,7 @@ QList<QAction*> ScreenSaver::availableActions()
     QList<QAction*> ret;
     QAction * act;
 
-    act = new QAction(XdgIcon::fromTheme(QL1S("system-lock-screen"), QL1S("lock")), tr("Lock Screen"), this);
+    act = new QAction(XdgIcon::fromTheme(QL1SV("system-lock-screen"), QL1SV("lock")), tr("Lock Screen"), this);
     connect(act, &QAction::triggered, this, &ScreenSaver::lockScreen);
     ret.append(act);
 

--- a/lxqtsettings.cpp
+++ b/lxqtsettings.cpp
@@ -52,9 +52,9 @@ public:
     {
         // HACK: we need to ensure that the user (~/.config/lxqt/<module>.conf)
         //       exists to have functional mWatcher
-        if (!mParent->contains(QL1S("__userfile__")))
+        if (!mParent->contains(QL1SV("__userfile__")))
         {
-            mParent->setValue(QL1S("__userfile__"), true);
+            mParent->setValue(QL1SV("__userfile__"), true);
             mParent->sync();
         }
         mWatcher.addPath(mParent->fileName());
@@ -393,7 +393,7 @@ LXQtTheme::LXQtTheme(const QString &path):
     }
 
     if (QDir(path).exists(QStringLiteral("preview.png")))
-        d->mPreviewImg = path + QL1S("/preview.png");
+        d->mPreviewImg = path + QL1SV("/preview.png");
 }
 
 
@@ -502,7 +502,7 @@ QString LXQtTheme::qss(const QString& module) const
 QString LXQtThemeData::loadQss(const QString& qssFile) const
 {
     // TODO: original QRegExp, check new syntax and QRegExp::RegExp2 meaning
-    // QRegExp(QL1S("url.[ \\t\\s]*"), Qt::CaseInsensitive, QRegExp::RegExp2);
+    // QRegExp(QL1SV("url.[ \\t\\s]*"), Qt::CaseInsensitive, QRegExp::RegExp2);
     static const QRegularExpression urlRegexp(QStringLiteral("url.[ \\t\\s]*"), QRegularExpression::CaseInsensitiveOption);
 
     QFile f(qssFile);
@@ -519,7 +519,7 @@ QString LXQtThemeData::loadQss(const QString& qssFile) const
 
     // handle relative paths
     QString qssDir = QFileInfo(qssFile).canonicalPath();
-    qss.replace(urlRegexp, QL1S("url(") + qssDir + QL1C('/'));
+    qss.replace(urlRegexp, QL1SV("url(") + qssDir + QL1C('/'));
 
     return qss;
 }
@@ -539,15 +539,15 @@ QString LXQtTheme::desktopBackground(int screen) const
     QString themeDir = QFileInfo(wallpaperCfgFileName).absolutePath();
     // There is something strange... If I remove next line the wallpapers array is not found...
     s.childKeys();
-    s.beginReadArray(QL1S("wallpapers"));
+    s.beginReadArray(QL1SV("wallpapers"));
 
     s.setArrayIndex(screen - 1);
-    if (s.contains(QL1S("file")))
-        return QDir::cleanPath(QString::fromLatin1("%1/%2").arg(themeDir, s.value(QL1S("file")).toString()));
+    if (s.contains(QL1SV("file")))
+        return QDir::cleanPath(QString::fromLatin1("%1/%2").arg(themeDir, s.value(QL1SV("file")).toString()));
 
     s.setArrayIndex(0);
-    if (s.contains(QL1S("file")))
-        return QDir::cleanPath(QString::fromLatin1("%1/%2").arg(themeDir, s.value(QL1S("file")).toString()));
+    if (s.contains(QL1SV("file")))
+        return QDir::cleanPath(QString::fromLatin1("%1/%2").arg(themeDir, s.value(QL1SV("file")).toString()));
 
     return QString();
 }
@@ -559,7 +559,7 @@ QString LXQtTheme::desktopBackground(int screen) const
 const LXQtTheme &LXQtTheme::currentTheme()
 {
     static LXQtTheme theme;
-    QString name = Settings::globalSettings()->value(QL1S("theme")).toString();
+    QString name = Settings::globalSettings()->value(QL1SV("theme")).toString();
     if (theme.name() != name)
     {
         theme = LXQtTheme(name);
@@ -660,15 +660,15 @@ GlobalSettings::GlobalSettings():
     Settings(QStringLiteral("lxqt")),
     d_ptr(new GlobalSettingsPrivate(this))
 {
-    if (value(QL1S("icon_theme")).toString().isEmpty())
+    if (value(QL1SV("icon_theme")).toString().isEmpty())
     {
         qWarning() << QString::fromLatin1("Icon Theme not set. Fallbacking to Oxygen, if installed");
-        const QString fallback(QL1S("oxygen"));
+        const QString fallback(QL1SV("oxygen"));
 
         const QDir dir(QStringLiteral(LXQT_DATA_DIR) + QStringLiteral("/icons"));
         if (dir.exists(fallback))
         {
-            setValue(QL1S("icon_theme"), fallback);
+            setValue(QL1SV("icon_theme"), fallback);
             sync();
         }
         else
@@ -695,14 +695,14 @@ void GlobalSettings::fileChanged()
     sync();
 
 
-    QString it = value(QL1S("icon_theme")).toString();
+    QString it = value(QL1SV("icon_theme")).toString();
     if (d->mIconTheme != it)
     {
         Q_EMIT iconThemeChanged();
     }
 
-    QString rt = value(QL1S("theme")).toString();
-    qlonglong themeUpdated = value(QL1S("__theme_updated__")).toLongLong();
+    QString rt = value(QL1SV("theme")).toString();
+    qlonglong themeUpdated = value(QL1SV("__theme_updated__")).toLongLong();
     if ((d->mLXQtTheme != rt) || (d->mThemeUpdated != themeUpdated))
     {
         d->mLXQtTheme = rt;

--- a/lxqtsettings.cpp
+++ b/lxqtsettings.cpp
@@ -111,7 +111,7 @@ public:
 
  ************************************************/
 Settings::Settings(const QString& module, QObject* parent) :
-    QSettings(QL1S("lxqt"), module, parent),
+    QSettings(QStringLiteral("lxqt"), module, parent),
     d_ptr(new SettingsPrivate(this))
 {
 }
@@ -392,7 +392,7 @@ LXQtTheme::LXQtTheme(const QString &path):
         d->mValid = !(d->mPath.isEmpty());
     }
 
-    if (QDir(path).exists(QL1S("preview.png")))
+    if (QDir(path).exists(QStringLiteral("preview.png")))
         d->mPreviewImg = path + QL1S("/preview.png");
 }
 
@@ -406,7 +406,7 @@ QString LXQtThemeData::findTheme(const QString &themeName)
         return QString();
 
     QStringList paths;
-    QLatin1String fallback(LXQT_INSTALL_PREFIX);
+    QLatin1StringView fallback(LXQT_INSTALL_PREFIX);
 
     paths << XdgDirs::dataHome(false);
     paths << XdgDirs::dataDirs();
@@ -503,7 +503,7 @@ QString LXQtThemeData::loadQss(const QString& qssFile) const
 {
     // TODO: original QRegExp, check new syntax and QRegExp::RegExp2 meaning
     // QRegExp(QL1S("url.[ \\t\\s]*"), Qt::CaseInsensitive, QRegExp::RegExp2);
-    static const QRegularExpression urlRegexp(QLatin1String("url.[ \\t\\s]*"), QRegularExpression::CaseInsensitiveOption);
+    static const QRegularExpression urlRegexp(QStringLiteral("url.[ \\t\\s]*"), QRegularExpression::CaseInsensitiveOption);
 
     QFile f(qssFile);
     if (! f.open(QIODevice::ReadOnly | QIODevice::Text))
@@ -588,7 +588,7 @@ QList<LXQtTheme> LXQtTheme::allThemes()
         for(const QFileInfo &dir : dirs)
         {
             if (!processed.contains(dir.fileName()) &&
-                 QDir(dir.absoluteFilePath()).exists(QL1S("lxqt-panel.qss")))
+                 QDir(dir.absoluteFilePath()).exists(QStringLiteral("lxqt-panel.qss")))
             {
                 processed << dir.fileName();
                 ret << LXQtTheme(dir.absoluteFilePath());
@@ -657,15 +657,15 @@ void SettingsCache::loadToSettings()
 
  ************************************************/
 GlobalSettings::GlobalSettings():
-    Settings(QL1S("lxqt")),
+    Settings(QStringLiteral("lxqt")),
     d_ptr(new GlobalSettingsPrivate(this))
 {
     if (value(QL1S("icon_theme")).toString().isEmpty())
     {
         qWarning() << QString::fromLatin1("Icon Theme not set. Fallbacking to Oxygen, if installed");
-        const QString fallback(QLatin1String("oxygen"));
+        const QString fallback(QL1S("oxygen"));
 
-        const QDir dir(QLatin1String(LXQT_DATA_DIR) + QLatin1String("/icons"));
+        const QDir dir(QStringLiteral(LXQT_DATA_DIR) + QStringLiteral("/icons"));
         if (dir.exists(fallback))
         {
             setValue(QL1S("icon_theme"), fallback);

--- a/lxqtsingleapplication.cpp
+++ b/lxqtsingleapplication.cpp
@@ -47,8 +47,8 @@ SingleApplication::SingleApplication(int &argc, char **argv, StartOptions option
     QDBusConnection bus = QDBusConnection::sessionBus();
 
     if (!bus.isConnected()) {
-        QLatin1String errorMessage("Can't connect to the D-Bus session bus\n"
-                                   "Make sure the D-Bus daemon is running");
+        QLatin1StringView errorMessage("Can't connect to the D-Bus session bus\n"
+                                       "Make sure the D-Bus daemon is running");
 
         /* ExitOnDBusFailure is the default. Any value other than
            NoExitOnDBusFailure will be taken as ExitOnDBusFailure (the default).
@@ -66,7 +66,7 @@ SingleApplication::SingleApplication(int &argc, char **argv, StartOptions option
                        QDBusConnectionInterface::ServiceRegistered);
     if (registered) { // We are the primary instance
         SingleApplicationAdaptor *mAdaptor = new SingleApplicationAdaptor(this);
-        QLatin1String objectPath("/");
+        QLatin1StringView objectPath("/");
         bus.registerObject(objectPath, mAdaptor,
             QDBusConnection::ExportAllSlots);
     } else { // We are the second outstance

--- a/lxqttranslator.cpp
+++ b/lxqttranslator.cpp
@@ -110,8 +110,8 @@ bool translate(const QString &name, const QString &owner)
                 QCoreApplication::installTranslator(appTranslator);
                 return true;
             }
-            else if (locale == QLatin1String("C") ||
-                        locale.startsWith(QLatin1String("en")))
+            else if (locale == QL1S("C") ||
+                        locale.startsWith(QL1S("en")))
             {
                 // English is the default. Even if there isn't an translation
                 // file, we return true. It's translated anyway.
@@ -180,7 +180,7 @@ bool Translator::translatePlugin(const QString &pluginName, const QString& type)
 
 static void loadSelfTranslation()
 {
-    Translator::translateLibrary(QLatin1String("liblxqt"));
+    Translator::translateLibrary(QStringLiteral("liblxqt"));
 }
 
 Q_COREAPP_STARTUP_FUNCTION(loadSelfTranslation)

--- a/lxqttranslator.cpp
+++ b/lxqttranslator.cpp
@@ -51,8 +51,8 @@ QStringList *getSearchPaths()
     if (searchPath == nullptr)
     {
         searchPath = new QStringList();
-        *searchPath << XdgDirs::dataDirs(QL1C('/') + QL1S(LXQT_RELATIVE_SHARE_TRANSLATIONS_DIR));
-        *searchPath << QL1S(LXQT_SHARE_TRANSLATIONS_DIR);
+        *searchPath << XdgDirs::dataDirs(QL1C('/') + QL1SV(LXQT_RELATIVE_SHARE_TRANSLATIONS_DIR));
+        *searchPath << QL1SV(LXQT_SHARE_TRANSLATIONS_DIR);
         searchPath->removeDuplicates();
     }
 
@@ -110,8 +110,8 @@ bool translate(const QString &name, const QString &owner)
                 QCoreApplication::installTranslator(appTranslator);
                 return true;
             }
-            else if (locale == QL1S("C") ||
-                        locale.startsWith(QL1S("en")))
+            else if (locale == QL1SV("C") ||
+                        locale.startsWith(QL1SV("en")))
             {
                 // English is the default. Even if there isn't an translation
                 // file, we return true. It's translated anyway.
@@ -135,7 +135,7 @@ bool Translator::translateApplication(const QString &applicationName)
     const QString locale = QLocale::system().name();
     QTranslator *qtTranslator = new QTranslator(qApp);
 
-    if (qtTranslator->load(QL1S("qt_") + locale, QLibraryInfo::path(QLibraryInfo::TranslationsPath)))
+    if (qtTranslator->load(QL1SV("qt_") + locale, QLibraryInfo::path(QLibraryInfo::TranslationsPath)))
     {
         qApp->installTranslator(qtTranslator);
     }


### PR DESCRIPTION
See https://doc.qt.io/qt-6/qlatin1string.html.

Also, `QStringLiteral` is used where a function is not overloaded to take `QLatin1StringView`. See the note below https://doc.qt.io/qt-6/qlatin1stringview.html#details for the reason.