### PR TITLE
Issues 2124 allowing adding item before the first item in LXQt::GridLayout

### DIFF
--- a/lxqtgridlayout.cpp
+++ b/lxqtgridlayout.cpp
@@ -244,11 +244,13 @@ GridLayout::~GridLayout()
  ************************************************/
 void GridLayout::addItem(QLayoutItem *item)
 {
-    if(d_ptr->mItemAppendingLocation == GridLayout::ItemAppendingLocation::BeforeFirstOfList){
+    if(d_ptr->mItemAppendingLocation == GridLayout::ItemAppendingLocation::BeforeFirstOfList)
+    {
         d_ptr->mItems.prepend(item);
         return;
     }
-    if(d_ptr->mItemAppendingLocation == GridLayout::ItemAppendingLocation::AfterLastOfList){
+    if(d_ptr->mItemAppendingLocation == GridLayout::ItemAppendingLocation::AfterLastOfList)
+    {
         d_ptr->mItems.append(item);
         return;
     }

--- a/lxqtgridlayout.cpp
+++ b/lxqtgridlayout.cpp
@@ -45,6 +45,8 @@ public:
     int mColumnCount;
     GridLayout::Direction mDirection;
 
+    GridLayout::ItemAppendingLocation mItemAppendingLocation;
+
     bool mIsValid;
     QSize mCellSizeHint;
     QSize mCellMaxSize;
@@ -104,6 +106,7 @@ GridLayoutPrivate::GridLayoutPrivate()
     mColumnCount = 0;
     mRowCount = 0;
     mDirection = GridLayout::LeftToRight;
+    mItemAppendingLocation = GridLayout::AfterLastOfList;
     mIsValid = false;
     mVisibleCount = 0;
     mStretch = GridLayout::StretchHorizontal | GridLayout::StretchVertical;
@@ -241,7 +244,14 @@ GridLayout::~GridLayout()
  ************************************************/
 void GridLayout::addItem(QLayoutItem *item)
 {
-    d_ptr->mItems.append(item);
+    if(d_ptr->mItemAppendingLocation == GridLayout::ItemAppendingLocation::BeforeFirstOfList){
+        d_ptr->mItems.prepend(item);
+        return;
+    }
+    if(d_ptr->mItemAppendingLocation == GridLayout::ItemAppendingLocation::AfterLastOfList){
+        d_ptr->mItems.append(item);
+        return;
+    }
 }
 
 
@@ -363,7 +373,29 @@ void GridLayout::setDirection(GridLayout::Direction value)
         invalidate();
     }
 }
+ 
+/************************************************
 
+************************************************/
+GridLayout::ItemAppendingLocation  GridLayout::itemAppendingLocation() const
+{
+    Q_D(const GridLayout);
+    return d->mItemAppendingLocation;
+}
+
+
+/************************************************
+
+************************************************/
+void GridLayout::setItemAppendingLocation(GridLayout::ItemAppendingLocation value)
+{
+    Q_D(GridLayout);
+     if (d->mItemAppendingLocation != value)
+     {
+         d->mItemAppendingLocation = value;
+         invalidate();
+     }
+}
 /************************************************
 
  ************************************************/

--- a/lxqtgridlayout.h
+++ b/lxqtgridlayout.h
@@ -67,6 +67,17 @@ public:
     };
     Q_DECLARE_FLAGS(Stretch, StretchFlag)
 
+     /**
+       This enum type is used to describe the location of the newly added item.
+      **/
+     enum ItemAppendingLocation
+     {
+         BeforeFirstOfList,    ///< The new Item is inserted before the first of the list.
+         AfterLastOfList     ///< The new item is inserted after the last of the list.
+     };
+ 
+
+
 
 
     /**
@@ -139,6 +150,22 @@ public:
     \sa  GridLayout::Direction
     **/
     void setDirection(Direction value);
+
+     /**
+     Returns the way we insert new items.
+ 
+     \sa  GridLayout::ItemAppendingLocation
+     **/
+     ItemAppendingLocation itemAppendingLocation() const;
+ 
+     /**
+      Sets the way we insert new items for this grid.
+ 
+     \sa  GridLayout::ItemAppendingLocation
+     **/
+     void setItemAppendingLocation(ItemAppendingLocation value);
+ 
+
 
     /**
     Returns the stretch flags of this grid.


### PR DESCRIPTION
The current implementation of LXQt::GridLayout does not allow us to fix issue  https://github.com/lxqt/lxqt-panel/pull/2125 which is changing the way new item inserting into StatusNotifierWidget, this would allow us to fix it