### PR TITLE
Support logout from `SystemdProvider`

### DIFF
--- a/lxqtpower/lxqtpowerproviders.cpp
+++ b/lxqtpower/lxqtpowerproviders.cpp
@@ -30,6 +30,7 @@
 #include "lxqtpowerproviders.h"
 #include <QDBusInterface>
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QGuiApplication>
 #include <QDebug>
 #include "lxqtnotification.h"
@@ -75,7 +76,8 @@ static bool dbusCall(const QString &service,
               const QString &interface,
               const QDBusConnection &connection,
               const QString & method,
-              PowerProvider::DbusErrorCheck errorCheck = PowerProvider::CheckDBUS
+              PowerProvider::DbusErrorCheck errorCheck = PowerProvider::CheckDBUS,
+              const QVariantList &args = QVariantList()
               )
 {
     QDBusInterface dbus(service, path, interface, connection);
@@ -92,7 +94,7 @@ static bool dbusCall(const QString &service,
         return false;
     }
 
-    QDBusMessage msg = dbus.call(method);
+    QDBusMessage msg = !args.isEmpty() ? dbus.callWithArgumentList(QDBus::Block, method, args) : dbus.call(method);
 
     if (!msg.errorName().isEmpty())
     {
@@ -403,6 +405,19 @@ SystemdProvider::~SystemdProvider() = default;
 
 bool SystemdProvider::canAction(Power::Action action) const
 {
+    if (action == Power::PowerLogout)
+    {
+        const QByteArray sessionId = qgetenv("XDG_SESSION_ID");
+        if (sessionId.isEmpty())
+            return false;
+
+        QDBusInterface dbus(QL1SV(SYSTEMD_SERVICE),
+                            QL1SV(SYSTEMD_PATH),
+                            QL1SV(SYSTEMD_INTERFACE),
+                            QDBusConnection::systemBus());
+        return dbus.isValid();
+    }
+
     QString command;
 
     switch (action)
@@ -443,6 +458,21 @@ bool SystemdProvider::canAction(Power::Action action) const
 
 bool SystemdProvider::doAction(Power::Action action)
 {
+    if (action == Power::PowerLogout)
+    {
+        const QByteArray sessionId = qgetenv("XDG_SESSION_ID");
+        if (sessionId.isEmpty())
+            return false;
+
+        return dbusCall(QL1SV(SYSTEMD_SERVICE),
+                        QL1SV(SYSTEMD_PATH),
+                        QL1SV(SYSTEMD_INTERFACE),
+                        QDBusConnection::systemBus(),
+                        QL1SV("TerminateSession"),
+                        PowerProvider::CheckDBUS,
+                        QVariantList() << QString::fromLocal8Bit(sessionId));
+    }
+
     QString command;
 
     switch (action)

--- a/lxqtpower/lxqtpowerproviders.cpp
+++ b/lxqtpower/lxqtpowerproviders.cpp
@@ -405,7 +405,11 @@ SystemdProvider::~SystemdProvider() = default;
 
 bool SystemdProvider::canAction(Power::Action action) const
 {
-    if (action == Power::PowerLogout)
+    QString command;
+
+    switch (action)
+    {
+    case Power::PowerLogout:
     {
         const QByteArray sessionId = qgetenv("XDG_SESSION_ID");
         if (sessionId.isEmpty())
@@ -418,10 +422,6 @@ bool SystemdProvider::canAction(Power::Action action) const
         return dbus.isValid();
     }
 
-    QString command;
-
-    switch (action)
-    {
     case Power::PowerReboot:
         command = QL1SV("CanReboot");
         break;
@@ -458,7 +458,11 @@ bool SystemdProvider::canAction(Power::Action action) const
 
 bool SystemdProvider::doAction(Power::Action action)
 {
-    if (action == Power::PowerLogout)
+    QString command;
+
+    switch (action)
+    {
+    case Power::PowerLogout:
     {
         const QByteArray sessionId = qgetenv("XDG_SESSION_ID");
         if (sessionId.isEmpty())
@@ -473,10 +477,6 @@ bool SystemdProvider::doAction(Power::Action action)
                         QVariantList() << QString::fromLocal8Bit(sessionId));
     }
 
-    QString command;
-
-    switch (action)
-    {
     case Power::PowerReboot:
         command = QL1SV("Reboot");
         break;


### PR DESCRIPTION
### Background

`lxqtpower` provides a provider mechanism. Providers are initialized in https://github.com/lxqt/liblxqt/blob/46711d90d337552539656da57a0d013e6ec6fc50/lxqtpower/lxqtpower.cpp#L39-L45 according to these rules:

- If `useLxqtSessionProvider` is true, then `LXQtProvider` is initialized. This communicates with `lxqt-session` via DBus.
- `SystemdProvider` is unconditionally initialized with lower precedence.

When power actions are performed, the providers are tried in order: https://github.com/lxqt/liblxqt/blob/46711d90d337552539656da57a0d013e6ec6fc50/lxqtpower/lxqtpower.cpp#L57-L81 So first `LXQtProvider` is tried (if `useLxqtSessionProvider` is true), and then `SystemdProvider` is tried. Thus we have established that `lxqtpower` does not depend on `lxqt-session`.

### Problem

When `SystemdProvider` is in use (i.e., when `lxqt-session` is not running), `lxqt-leave` shows a grayed-out logout button, but the shutdown and reboot buttons are not grayed out.

### Evaluation

`SystemdProvider::canAction` and `SystemdProvider::doAction` include case statements for `case Power::PowerShutdown` and `case Power::PowerReboot`, but not for `case Power::PowerLogout`: https://github.com/lxqt/liblxqt/blob/46711d90d337552539656da57a0d013e6ec6fc50/lxqtpower/lxqtpowerproviders.cpp#L404-L477

### Solution

As discussed in https://github.com/lxqt/lxqt-wayland-session/issues/105#issuecomment-3710858488, add the missing case, calling systemd's `TerminateSession` via DBus. This is the equivalent of `loginctl terminate-session` ([man page](https://www.freedesktop.org/software/systemd/man/latest/loginctl.html)) which is documented as follows:

> Terminates a session. This kills all processes of the session and deallocates all resources attached to the session.

### Implementation details

`XDG_SESSION_ID` is set by systemd-logind for a user session. If it's missing, we are not running inside a logind-managed session and consider the functionality unavailable. systemd does not offer a `CanLogout` or `CanTerminateSession` method analogous to `CanReboot`, `CanPowerOff`, etc. So we therefore check if we have an `XDG_SESSION_ID` and that the DBus service, object, and interface are present on the system bus, then consider the functionality available.

For actually logging out the user, `TerminateSession` takes a string ID rather than an `interactive` boolean like the `PowerOff` and `Reboot` methods, so the `dbusCallSystemd` function is not suitable. Instead, we modify the `dbusCall` method to support arbitrary arguments (with a default value of no arguments). If binary compatibility is a concern, I can leave the existing function signature alone and create a new signature for invoking DBus methods with arguments.

### Testing done

Tested in Fedora 43 under UWSM (without `lxqt-session` running). Before this PR, the logout button was grayed out. After this PR, it is not grayed out, and clicking it logs out the session.