### PR TITLE
update fsf address

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
                        Version 2.1, February 1999
 
  Copyright (C) 1991, 1999 Free Software Foundation, Inc.
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ <https://fsf.org>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/configdialog/lxqtconfigdialog.h
+++ b/configdialog/lxqtconfigdialog.h
@@ -17,8 +17,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/configdialog/lxqtpageselectwidget.h
+++ b/configdialog/lxqtpageselectwidget.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtapplication.h
+++ b/lxqtapplication.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtautostartentry.h
+++ b/lxqtautostartentry.h
@@ -17,8 +17,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtbacklight.h
+++ b/lxqtbacklight.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtglobals.h
+++ b/lxqtglobals.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtgridlayout.h
+++ b/lxqtgridlayout.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqthtmldelegate.h
+++ b/lxqthtmldelegate.h
@@ -20,9 +20,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtnotification.h
+++ b/lxqtnotification.h
@@ -17,8 +17,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtplugininfo.h
+++ b/lxqtplugininfo.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtpower/lxqtpower.h
+++ b/lxqtpower/lxqtpower.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtpowermanager.h
+++ b/lxqtpowermanager.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtprogramfinder.h
+++ b/lxqtprogramfinder.h
@@ -17,8 +17,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtrotatedwidget.h
+++ b/lxqtrotatedwidget.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtscreensaver.h
+++ b/lxqtscreensaver.h
@@ -21,9 +21,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtsettings.h
+++ b/lxqtsettings.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqtsingleapplication.h
+++ b/lxqtsingleapplication.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/lxqttranslator.h
+++ b/lxqttranslator.h
@@ -20,9 +20,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 


### PR DESCRIPTION
See https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html for the most current published address

On rpm based systems, when building, the old fsf address throws an Error in rpmlint.

This PR doesn't change any functionality, it's completely administrative.