### PR TITLE
Apply LXQt CMake settings to all code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,11 @@ message(STATUS "Building ${PROJECT_NAME} with Qt ${Qt6Core_VERSION}")
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs) # Standard directories for installation
+include(LXQtPreventInSourceBuilds)
+include(LXQtCompilerSettings NO_POLICY_SCOPE)
+include(LXQtCreatePkgConfigFile)
+include(LXQtCreatePortableHeaders)
+include(LXQtConfigVars)
 
 if (BUILD_BACKLIGHT_LINUX_BACKEND)
     add_subdirectory(lxqtbacklight/linux_backend/driver)
@@ -216,14 +221,6 @@ list(APPEND SRCS "${DBUS_INTERFACE_SRCS}" "${DBUS_ADAPTOR_SRCS}")
 
 # KF6WindowSystem is missing here. KF5WindowSystem doesn't provide an .pc file. TODO: check if things changed in KF6
 set(LXQT_PKG_CONFIG_REQUIRES "Qt6Xdg >= ${QTXDG_MINIMUM_VERSION}, Qt6Widgets >= ${QT_MINIMUM_VERSION}, Qt6Xml >= ${QT_MINIMUM_VERSION}, Qt6DBus >= ${QT_MINIMUM_VERSION}")
-
-
-# Standard directories for installation
-include(LXQtPreventInSourceBuilds)
-include(LXQtCompilerSettings NO_POLICY_SCOPE)
-include(LXQtCreatePkgConfigFile)
-include(LXQtCreatePortableHeaders)
-include(LXQtConfigVars)
 
 set(LXQT_INTREE_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/include")
 

--- a/lxqtbacklight/linux_backend/driver/CMakeLists.txt
+++ b/lxqtbacklight/linux_backend/driver/CMakeLists.txt
@@ -8,7 +8,6 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
 )
-
 add_executable(${PROJECT_NAME}
     ${C_FILES}
 )

--- a/lxqtbacklight/linux_backend/driver/lxqtbacklight_backend.c
+++ b/lxqtbacklight/linux_backend/driver/lxqtbacklight_backend.c
@@ -25,6 +25,8 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdio.h>
 #include <dirent.h>
 #include <errno.h>


### PR DESCRIPTION
LXQt CMake Settings should be applied to all code. That translates to
including the CMake files before adding directories.

lxqtbacklight/linux_backend/driver was added before LXQtCompilerSettings
were included. That meant that the `lxqt-backlight_backend` target didn't
use LXQtCompilerSettings settings, e.g., CMAE_C_STANDARD.

strdup() and popen() are not part of C99. They are POSIX functions.
